### PR TITLE
Gradle task handles output that overflows buffer

### DIFF
--- a/src/main/kotlin/org/javacs/kt/classpath/gradleDependencyResolver.kt
+++ b/src/main/kotlin/org/javacs/kt/classpath/gradleDependencyResolver.kt
@@ -77,8 +77,6 @@ private fun readDependenciesViaTask(directory: Path): Set<Path>? {
     val artifact = Pattern.compile("^.+?\\.jar$")
     val dependencies = mutableSetOf<Path>()
 
-    classpathCommand.waitFor()
-
     stdout.bufferedReader().use { reader ->
         for (dependency in reader.lines()) {
             val line = dependency.toString().trim()
@@ -88,6 +86,8 @@ private fun readDependenciesViaTask(directory: Path): Set<Path>? {
             }
         }
     }
+
+    classpathCommand.waitFor()
 
     if (dependencies.size > 0) {
         return dependencies


### PR DESCRIPTION
I've got a very fairly large project where querying the Gradle task for dependencies apparently generates more output than fits in a standard buffer - waiting on the process before draining the input creates a deadlock.