### PR TITLE
Fix import completion StringIndexOutOfBoundsException on base package

### DIFF
--- a/src/main/kotlin/org/javacs/kt/completion/completions.kt
+++ b/src/main/kotlin/org/javacs/kt/completion/completions.kt
@@ -112,7 +112,7 @@ private fun doCompletions(file: CompiledFile, cursor: Int, surroundingElement: K
             LOG.info("Completing import '${surroundingElement.text}'")
             val module = file.container.get<ModuleDescriptor>()
             val match = Regex("import ((\\w+\\.)*)[\\w*]*").matchEntire(surroundingElement.text) ?: return doesntLookLikeImport(surroundingElement)
-            val parentDot = match.groups[1]?.value ?: "."
+            val parentDot = if (match.groupValues[1].isNotBlank()) match.groupValues[1] else "."
             val parent = parentDot.substring(0, parentDot.length - 1)
             LOG.fine("Looking for members of package '$parent'")
             val parentPackage = module.getPackage(FqName.fromSegments(parent.split('.')))

--- a/src/test/kotlin/org/javacs/kt/CompletionsTest.kt
+++ b/src/test/kotlin/org/javacs/kt/CompletionsTest.kt
@@ -195,6 +195,13 @@ class ImportsTest: SingleFileTestFixture("completions", "Imports.kt") {
 
         assertThat(labels, hasItems("MethodHandle"))
     }
+
+    @Test fun `complete import from j`() {
+        val completions = languageServer.textDocumentService.completion(completionParams(file, 5, 9)).get().right!!
+        val labels = completions.items.map { it.label }
+
+        assertThat(labels, hasItems("java"))
+    }
 }
 
 class DoubleDotTest: SingleFileTestFixture("completions", "DoubleDot.kt") {

--- a/src/test/resources/completions/Imports.kt
+++ b/src/test/resources/completions/Imports.kt
@@ -1,3 +1,5 @@
 import java.nio.file.P
 // Import something else
 import java.lang.invoke.
+// Import base package
+import j


### PR DESCRIPTION
When calling auto completion on the following string (cursor at the end):
```java
import j
```

A StringIndexOutOfBoundsException exception is thrown:
```log
[INFO]      async       main    Re-parsing File.kt 0:1-52:1
[INFO]      async       main    Completing import 'import j'
[INFO]      async       main    Finished in 2 ms
[SEVERE]    async       org.ec  Internal error: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
                        lipse.
                        lsp4j.
                        jsonrp
                        c.Remo
                        teEndp
                        oint  

java.util.concurrent.CompletionException: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:273)
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:280)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1592)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at java.lang.String.substring(String.java:1967)
	at org.javacs.kt.completion.CompletionsKt.doCompletions(completions.kt:117)
	at org.javacs.kt.completion.CompletionsKt.completions(completions.kt:39)
	at org.javacs.kt.KotlinTextDocumentService$completion$1.invoke(KotlinTextDocumentService.kt:99)
	at org.javacs.kt.KotlinTextDocumentService$completion$1.invoke(KotlinTextDocumentService.kt:26)
	at org.javacs.kt.util.AsyncUtilsKt$sam$java_util_function_Supplier$0.get(asyncUtils.kt)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1590)
	... 3 more

[INFO]      debounce-0  main    Linting .../server/File.kt
[INFO]      debounce-0  main    Reported 1 diagnostics in File.kt
```