### PR TITLE
Added support for `\r\n` line breaks in Gradle CLI dependency parsing.

### DIFF
--- a/src/main/kotlin/org/javacs/kt/classpath/gradleDependencyResolver.kt
+++ b/src/main/kotlin/org/javacs/kt/classpath/gradleDependencyResolver.kt
@@ -66,7 +66,7 @@ private fun findGradleCLIDependencies(command: String, projectDirectory: Path): 
     return parseGradleCLIDependencies(result)
 }
 
-private val artifactPattern by lazy { "kotlin-lsp-gradle (.+)(\\r?\\n)".toRegex(RegexOption.MULTILINE) }
+private val artifactPattern by lazy { "kotlin-lsp-gradle (.+)(\r?\n)".toRegex(RegexOption.MULTILINE) }
 
 private fun parseGradleCLIDependencies(output: String): Set<Path>? {
     val artifacts = artifactPattern.findAll(output)

--- a/src/main/kotlin/org/javacs/kt/classpath/gradleDependencyResolver.kt
+++ b/src/main/kotlin/org/javacs/kt/classpath/gradleDependencyResolver.kt
@@ -66,7 +66,7 @@ private fun findGradleCLIDependencies(command: String, projectDirectory: Path): 
     return parseGradleCLIDependencies(result)
 }
 
-private val artifactPattern by lazy { "kotlin-lsp-gradle (.+)(\r?\n)".toRegex(RegexOption.MULTILINE) }
+private val artifactPattern by lazy { "kotlin-lsp-gradle (.+)(\r?\n)".toRegex() }
 
 private fun parseGradleCLIDependencies(output: String): Set<Path>? {
     val artifacts = artifactPattern.findAll(output)

--- a/src/main/kotlin/org/javacs/kt/classpath/gradleDependencyResolver.kt
+++ b/src/main/kotlin/org/javacs/kt/classpath/gradleDependencyResolver.kt
@@ -66,7 +66,7 @@ private fun findGradleCLIDependencies(command: String, projectDirectory: Path): 
     return parseGradleCLIDependencies(result)
 }
 
-private val artifactPattern by lazy { "kotlin-lsp-gradle (.+)\n".toRegex() }
+private val artifactPattern by lazy { "kotlin-lsp-gradle (.+)(\\r?\\n)".toRegex(RegexOption.MULTILINE) }
 
 private fun parseGradleCLIDependencies(output: String): Set<Path>? {
     val artifacts = artifactPattern.findAll(output)


### PR DESCRIPTION
I noticed this test failing on Windows 10 while trying to parse the console output from the temporary gradle file. The modification to the regex will work for both `\r\n` and `\n` line breaks coming from the stdout.