### PR TITLE
Fix intermediate deps for flavors other than debug.

### DIFF
--- a/src/main/resources/classpathFinder.gradle
+++ b/src/main/resources/classpathFinder.gradle
@@ -11,14 +11,20 @@ allprojects { project ->
 				}
 				if (project.android.hasProperty('applicationVariants')) {
 					project.android.applicationVariants.all { variant ->
+
+						def buildClasses = project.getBuildDir().absolutePath +
+															 File.separator + "intermediates" +
+															 File.separator + "classes" + 
+															 File.separator + variant.baseName.replaceAll("-", File.separator) 
+
+						System.out.println "kotlin-lsp-gradle $buildClasses"
+
 						variant.getCompileClasspath().each {
 							System.out.println "kotlin-lsp-gradle $it"
 						}
 					}
 				}
 
-				def buildClasses = project.getBuildDir().absolutePath + File.separator + "intermediates" + File.separator + "classes" + File.separator + "debug"
-				System.out.println "kotlin-lsp-gradle $buildClasses"
 			} else {
 				// Print the list of all dependencies jar files.
 				project.configurations.findAll {


### PR DESCRIPTION
Intermediate dependencies (e.g. R.class) were hard coded to the debug
build flavor. This commit fixes this by outputing the intermediate paths
for all flavors.

Note that there is no way to output only the dependencies for the flavor
being build at the moment. This script is executed before any particular
build (e.g. assembleDebug) is executed so we cannot know before hand
what deps to load. Fortunatelly most of the time, dependencies do not
conflict between flavors so loading them all should not be an issue
(most of the time).