### PR TITLE
Move + to the end of the lines so Gradle doesn't throw an error

### DIFF
--- a/src/main/resources/classpathFinder.gradle
+++ b/src/main/resources/classpathFinder.gradle
@@ -12,10 +12,10 @@ allprojects { project ->
 				if (project.android.hasProperty('applicationVariants')) {
 					project.android.applicationVariants.all { variant ->
 
-						def buildClasses = project.getBuildDir().absolutePath
-							+ File.separator + "intermediates"
-							+ File.separator + "classes"
-							+ File.separator + variant.baseName.replaceAll("-", File.separator) 
+						def buildClasses = project.getBuildDir().absolutePath +
+							File.separator + "intermediates" +
+							File.separator + "classes" +
+							File.separator + variant.baseName.replaceAll("-", File.separator)
 
 						System.out.println "kotlin-lsp-gradle $buildClasses"
 


### PR DESCRIPTION
8b80169d3d2ac5e360bd7d286c45bc593a068cdb introduced a change here that caused Gradle to throw an error when trying to get the classpath. I don't know much Groovy, but I think Groovy is understanding this like Line 15 and subsequent lines have a semi-colon at the end since there's no operator like `+` telling it to look at the next line