### PR TITLE
Updated org.eclipse.lsp4j to 0.5.0 from 0.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
 	implementation "com.google.guava:guava:21.0"
 	implementation "org.gradle:gradle-tooling-api:4.3"
-	implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.4.1"
+	implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.5.0"
 
 	implementation "org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion"
 	kotlinJVMLib tc("$kotlinTeamCity/lib/kotlin-plugin.jar")

--- a/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -49,12 +49,14 @@ class KotlinTextDocumentService(
         return Pair(compiled, offset)
     }
 
-    override fun codeAction(params: CodeActionParams): CompletableFuture<List<Command>> = async.compute {
+    override fun codeAction(params: CodeActionParams): CompletableFuture<List<Either<Command, CodeAction>>> = async.compute {
         listOf(
-            Command("Convert Java code to Kotlin", JAVA_TO_KOTLIN_COMMAND, listOf(
-                params.textDocument.uri,
-                params.range
-            ))
+            Either.forLeft<Command, CodeAction>(
+                Command("Convert Java code to Kotlin", JAVA_TO_KOTLIN_COMMAND, listOf(
+                    params.textDocument.uri,
+                    params.range
+                ))
+            )
         )
     }
 
@@ -113,7 +115,7 @@ class KotlinTextDocumentService(
         TODO("not implemented")
     }
 
-    override fun documentSymbol(params: DocumentSymbolParams) = async.compute {
+    override fun documentSymbol(params: DocumentSymbolParams): CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> = async.compute {
         LOG.info("Find symbols in {}", params.textDocument)
 
         reportTime {

--- a/src/main/kotlin/org/javacs/kt/symbols/symbols.kt
+++ b/src/main/kotlin/org/javacs/kt/symbols/symbols.kt
@@ -4,6 +4,8 @@ import com.intellij.psi.PsiElement
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.SymbolInformation
 import org.eclipse.lsp4j.SymbolKind
+import org.eclipse.lsp4j.DocumentSymbol
+import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.javacs.kt.SourcePath
 import org.javacs.kt.completion.containsCharactersInOrder
 import org.javacs.kt.position.range
@@ -12,8 +14,8 @@ import org.javacs.kt.util.toPath
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.parents
 
-fun documentSymbols(file: KtFile): List<SymbolInformation> =
-    doDocumentSymbols(file).mapNotNull(::symbolInformation).toList()
+fun documentSymbols(file: KtFile): List<Either<SymbolInformation, DocumentSymbol>> =
+        doDocumentSymbols(file).mapNotNull(::symbolInformation).toList().map { Either.forLeft<SymbolInformation, DocumentSymbol>(it) }
 
 private fun doDocumentSymbols(file: KtFile): Sequence<KtNamedDeclaration> =
         file.preOrderTraversal().mapNotNull { pickImportantElements(it, true) }
@@ -31,7 +33,7 @@ private fun doWorkspaceSymbols(sp: SourcePath): Sequence<KtNamedDeclaration> =
         sp.all().asSequence().flatMap(::fileSymbols)
 
 private fun fileSymbols(file: KtFile): Sequence<KtNamedDeclaration> =
-    file.preOrderTraversal().mapNotNull { pickImportantElements(it, false) }
+        file.preOrderTraversal().mapNotNull { pickImportantElements(it, false) }
 
 private fun pickImportantElements(node: PsiElement, includeLocals: Boolean): KtNamedDeclaration? =
         when (node) {

--- a/src/test/kotlin/org/javacs/kt/DocumentSymbolsTest.kt
+++ b/src/test/kotlin/org/javacs/kt/DocumentSymbolsTest.kt
@@ -19,8 +19,8 @@ class DocumentSymbolsTest: LanguageServerTestFixture("symbols") {
     @Test fun `find document symbols`() {
         val fileId = TextDocumentIdentifier(uri(file).toString())
         val found = languageServer.textDocumentService.documentSymbol(DocumentSymbolParams(fileId)).get()
-        val byKind = found.groupBy({ it.kind }, { it.name })
-        val all = found.map { it.name }.toList()
+        val byKind = found.groupBy({ it.left.kind }, { it.left.name })
+        val all = found.map { it.left.name }.toList()
 
         assertThat(byKind[SymbolKind.Class], hasItem("DocumentSymbols"))
         assertThat(byKind[SymbolKind.Constructor], hasItem("DocumentSymbols"))


### PR DESCRIPTION
3 places needed work to accomodate for changed method signatures with new `org.eclipse.lsp4j.jsonrpc.messages.Either` in their return types
