### PR TITLE
[WIP] Open java sources found in jar as downloaded by gradle

### DIFF
--- a/src/main/kotlin/org/javacs/kt/definition/goToDefinition.kt
+++ b/src/main/kotlin/org/javacs/kt/definition/goToDefinition.kt
@@ -23,12 +23,12 @@ fun goToDefinition(file: CompiledFile, cursor: Int): Location? {
     //        disabled until https://github.com/fwcd/KotlinLanguageServer/issues/45
     //        is resolved.
     
-    // if (destination != null) {
-    //     val rawClassURI = destination.uri
-    //     if (isInsideJar(rawClassURI)) {
-    //         destination.uri = cachedDecompile(rawClassURI)
-    //     }
-    // }
+    if (destination != null) {
+        val rawClassURI = destination.uri
+        if (isInsideJar(rawClassURI)) {
+            destination.uri = cachedDecompile(rawClassURI)
+        }
+    }
     
     return destination
 }

--- a/src/main/kotlin/org/javacs/kt/externalsources/ClassInJar.kt
+++ b/src/main/kotlin/org/javacs/kt/externalsources/ClassInJar.kt
@@ -1,5 +1,6 @@
 package org.javacs.kt.externalsources
 
+import java.io.File
 import java.nio.file.Path
 import java.net.URI
 import java.nio.file.Paths
@@ -10,35 +11,68 @@ import org.javacs.kt.util.KotlinLSException
 import org.javacs.kt.util.replaceExtensionWith
 
 fun parseUriAsClassInJar(uri: String): ClassInJar {
-	val splittedUri = uri.split(".jar!")
-	val jarUri = splittedUri[0] + ".jar"
+	val splitUri = uri.split(".jar!")
+	val jarUri = splitUri[0] + ".jar"
 	val jarPath = Paths.get(URI.create(jarUri))
-	val relativeClassPath = Paths.get(splittedUri[1].trimLeadingPathSeparator())
+	val relativeClassPath = Paths.get(splitUri[1].trimLeadingPathSeparator())
 
-	return ClassInJar(jarPath, relativeClassPath)
+    val relativeJavaPath = Paths.get((splitUri[1].split(".class")[0] + ".java").trimLeadingPathSeparator())
+
+	return ClassInJar(jarPath, relativeClassPath, relativeJavaPath)
 }
 
 class ClassInJar(
 	val jarPath: Path,
-	val relativeClassPath: Path
+	val relativeClassPath: Path,
+    val relativeJavaPath: Path
 ) {
 	val className: String
 	private val classExtension: String
 
+    val javaName: String
+    private val javaExtension: String
+
 	init {
-		val parsedName = relativeClassPath.fileName.parseName()
+		var parsedName = relativeClassPath.fileName.parseName()
 		className = parsedName.name
 		classExtension = parsedName.extension
+
+        parsedName = relativeJavaPath.fileName.parseName()
+		javaName = parsedName.name
+		javaExtension = parsedName.extension
 	}
 
 	fun toSourceClass(provider: SourceJarProvider): ClassInJar {
 		val sourceJarPath = provider.fetchSourceJar(jarPath)
-		return ClassInJar(sourceJarPath, relativeClassPath.replaceExtensionWith(".java"))
+        // Need to decided what to pass in for 3rd param
+		return ClassInJar(sourceJarPath, relativeClassPath.replaceExtensionWith(".java"), relativeClassPath.replaceExtensionWith(".java"))
 	}
 
-	fun decompile(decompiler: Decompiler) = decompiler.decompileClass(extract())
+    fun decompile(decompiler: Decompiler) = extractJava() ?: decompiler.decompileClass(extractClass())
 
-	fun extract(): Path {
+    fun extractJava(): Path? {
+        return JarFile(jarPath.toFile()).use { jarFile ->
+			val jarEntry = jarFile.entries().asSequence()
+					.filter { Paths.get(it.name).equals(relativeJavaPath) }
+					.firstOrNull()
+
+			if (jarEntry == null) {
+                LOG.warn("Could not find $javaName")
+                return null
+			}
+
+            val tmpDir = System.getProperty("java.io.tmpdir")
+
+            File("$tmpDir/${relativeJavaPath.parseDirectories()}/").mkdirs()
+            val tmpFile = File("$tmpDir/${relativeJavaPath.parseDirectories()}/$javaName$javaExtension")
+            tmpFile.createNewFile()
+			tmpFile.deleteOnExit() // Make sure the extracted file is deleted upon exit
+			tmpFile.outputStream().use { jarFile.getInputStream(jarEntry).copyTo(it) }
+			Paths.get(tmpFile.absolutePath)
+		}
+    }
+
+	fun extractClass(): Path {
 		return JarFile(jarPath.toFile()).use { jarFile ->
 			val jarEntry = jarFile.entries().asSequence()
 					.filter { Paths.get(it.name).equals(relativeClassPath) }
@@ -62,6 +96,12 @@ private data class FileName(val name: String, val extension: String)
 private fun String.trimLeadingPathSeparator(): String {
     val firstChar = this[0]
     return if (firstChar == '/' || firstChar == '\\') substring(1) else this
+}
+
+private fun Path.parseDirectories(): String {
+    val pathStr = toString()
+    val slashPos = pathStr.lastIndexOf("/")
+    return pathStr.substring(0, slashPos)
 }
 
 private fun Path.parseName(): FileName {


### PR DESCRIPTION
Java sources that exist in the jar files downloaded by gradle can now be opened

They are placed in `$TMP_DIR/<relative_path_in_jar>/<file>.java`
If java file not found, proceed with usual class file finding
Uncommented section in `goToDefinition.kt` as it doesnt seem to be causing any issues as seen so far
Sample used: `org.eclipse.lsp4j-0.5.0.jar`

I understand that this is still a very rough implementation which probably fails under edge cases. Naturally, #45 is resurfaced as a result if the java files dont exist, so this should probably not be merged until such time as we can sort that out.
Unfortunately, as the files extracted are Java files, we're at the whim of the features of the Java vscode extension after that if we're wanting to go down the chain of imports :smile: 