### PR TITLE
Improved Kotlin standard library dependency resolution

### DIFF
--- a/src/main/kotlin/org/javacs/kt/classpath/findClassPath.kt
+++ b/src/main/kotlin/org/javacs/kt/classpath/findClassPath.kt
@@ -28,10 +28,54 @@ fun findClassPath(workspaceRoots: Collection<Path>): Set<Path> {
 }
 
 private fun ensureStdlibInPaths(paths: Set<Path>): Set<Path> {
-    // Ensure that there is exactly one kotlin-stdlib present
+    // Ensure that there is exactly one kotlin-stdlib present, and/or exactly one of kotlin-stdlib-common, -jdk8, etc.
     val isStdlib: ((Path) -> Boolean) = { it.toString().contains("kotlin-stdlib") }
-    val stdlib = paths.firstOrNull(isStdlib) ?: findKotlinStdlib()
-    return paths.filterNot(isStdlib).union(listOf(stdlib).filterNotNull())
+
+    val linkedStdLibs = paths.filter(isStdlib)
+      .mapNotNull { StdLibItem.from(it) }
+      .groupBy { it.key }.map { candidates ->
+        // For each "kotlin-stdlib-blah", use the newest.  This may not be correct behavior if the project has lots of
+        // conflicting dependencies, but in general should get enough of the stdlib loaded that we can display errors
+
+        candidates.value.sortedWith(
+          compareByDescending<StdLibItem> { it.major } then
+            compareByDescending { it.minor }
+              then compareByDescending { it.patch }
+        ).first().path
+    }
+
+    val stdlibs = if (linkedStdLibs.isNotEmpty()) {
+        linkedStdLibs
+    } else {
+        findKotlinStdlib()?.let { listOf(it) } ?: listOf()
+    }
+
+    return paths.filterNot(isStdlib).union(stdlibs)
+}
+
+private data class StdLibItem(
+  val key : String,
+  val major : Int,
+  val minor: Int,
+  val patch : Int,
+  val path: Path
+) {
+    companion object {
+        // Matches names like: "kotlin-stdlib-jdk7-1.2.51.jar"
+        val parser = Regex("""(kotlin-stdlib(-[^-]+)?)-(\d+)\.(\d+)\.(\d+)\.jar""")
+
+        fun from(path: Path) : StdLibItem? {
+            return parser.matchEntire(path.fileName.toString())?.let { match ->
+                StdLibItem(
+                  key = match.groups[1]?.value ?: match.groups[0]?.value!!,
+                  major = match.groups[3]?.value?.toInt() ?: 0,
+                  minor = match.groups[4]?.value?.toInt() ?: 0,
+                  patch = match.groups[5]?.value?.toInt() ?: 0,
+                  path = path
+                )
+            }
+        }
+    }
 }
 
 private fun backupClassPath() =


### PR DESCRIPTION
The code to remove duplicate stdlib imports in in `ensureStdlibInPaths` can get confused with JDK-specialized stdlibs (e.g. `kotlin-stdlib-jdk7`).  These specialized instances only implement a subset of the Kotlin standard library that's optimized for that deployment target (or so it appears?), and need another library to implement the rest of the library (seems to be `kotlin-stdlib-common` for me).  

Current code may end up grabbing _just_ `kotlin-stdlib-jdk7` (or whatever) if it comes up first in the dependencies list, which leaves us missing most of the standard library methods.

PR code tries to pull in only one of each 'kind' of jar, and only the newest of each.  That's a pretty shallow heuristic but it seems to solve issues I've been seeing, which I think are identical to issues #56 and #58.

I'm not clear whether this would also cause #69 and #51, though I suspect it may be related(?).

I'm not sure what the original problem `ensureStdlibInPaths` solved looked like, so I can't tell if this would be a regression on that front.