### PR TITLE
Parameter lists in completion labels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "kotlin",
-    "version": "0.1.11",
+    "version": "0.1.12",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -315,7 +315,7 @@
         },
         "deep-assign": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
@@ -345,7 +345,7 @@
         },
         "duplexer": {
             "version": "0.1.1",
-            "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
             "dev": true
         },
@@ -412,7 +412,7 @@
         },
         "expand-range": {
             "version": "1.8.2",
-            "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
@@ -691,7 +691,7 @@
                 },
                 "readable-stream": {
                     "version": "1.0.34",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
@@ -703,13 +703,13 @@
                 },
                 "string_decoder": {
                     "version": "0.10.31",
-                    "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                     "dev": true
                 },
                 "through2": {
                     "version": "0.6.5",
-                    "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
@@ -771,7 +771,7 @@
                 },
                 "readable-stream": {
                     "version": "1.0.34",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
@@ -783,13 +783,13 @@
                 },
                 "string_decoder": {
                     "version": "0.10.31",
-                    "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                     "dev": true
                 },
                 "through2": {
                     "version": "0.6.5",
-                    "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
@@ -1204,7 +1204,7 @@
         },
         "is-obj": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
             "dev": true
         },
@@ -1342,7 +1342,7 @@
         },
         "kind-of": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
             "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
             "dev": true
         },
@@ -1372,7 +1372,7 @@
         },
         "map-stream": {
             "version": "0.1.0",
-            "resolved": "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
             "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
             "dev": true
         },
@@ -1473,13 +1473,13 @@
         },
         "minimist": {
             "version": "0.0.8",
-            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
             "dev": true
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
@@ -1662,13 +1662,13 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
         "pause-stream": {
             "version": "0.0.11",
-            "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
@@ -1793,7 +1793,7 @@
         },
         "readable-stream": {
             "version": "2.3.6",
-            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
@@ -1947,7 +1947,7 @@
         },
         "split": {
             "version": "0.3.3",
-            "resolved": "http://registry.npmjs.org/split/-/split-0.3.3.tgz",
+            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
@@ -1979,7 +1979,7 @@
         },
         "stream-combiner": {
             "version": "0.0.4",
-            "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
@@ -2009,7 +2009,7 @@
         },
         "string_decoder": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
@@ -2046,7 +2046,7 @@
         },
         "tar": {
             "version": "2.2.1",
-            "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
@@ -2057,7 +2057,7 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },

--- a/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -48,9 +48,12 @@ fun completions(file: CompiledFile, cursor: Int): CompletionList {
 }
 
 private val callPattern = Regex("(.*)\\((\\$\\d+)?\\)")
+private val methodSignature = Regex("""(?:fun|constructor) (?:<(?:[a-zA-Z\?\!\: ]+)(?:, [A-Z])*> )?([a-zA-Z]+\(.*\))""")
 
 private fun completionItem(d: DeclarationDescriptor, surroundingElement: KtElement, file: CompiledFile): CompletionItem {
     val result = d.accept(RenderCompletionItem(), null)
+
+    result.label = methodSignature.find(result.detail)?.groupValues?.get(1) ?: result.label
 
     if (isGetter(d) || isSetter(d)) {
         val name = extractVarName(d)

--- a/src/test/kotlin/org/javacs/kt/CompletionsTest.kt
+++ b/src/test/kotlin/org/javacs/kt/CompletionsTest.kt
@@ -10,15 +10,15 @@ class InstanceMemberTest : SingleFileTestFixture("completions", "InstanceMember.
         val completions = languageServer.textDocumentService.completion(completionParams(file, 3, 15)).get().right!!
         val labels = completions.items.map { it.label }
 
-        assertThat(labels, hasItem("instanceFoo"))
-        assertThat(labels, hasItem("extensionFoo"))
-        assertThat(labels, hasItem("fooVar"))
-        assertThat(labels, not(hasItem("privateInstanceFoo")))
-        assertThat(labels, not(hasItem("getFooVar")))
-        assertThat(labels, not(hasItem("setFooVar")))
+        assertThat(labels, hasItem(startsWith("instanceFoo")))
+        assertThat(labels, hasItem(startsWith("extensionFoo")))
+        assertThat(labels, hasItem(startsWith("fooVar")))
+        assertThat(labels, not(hasItem(startsWith("privateInstanceFoo"))))
+        assertThat(labels, not(hasItem(startsWith("getFooVar"))))
+        assertThat(labels, not(hasItem(startsWith("setFooVar"))))
 
-        assertThat("Reports instanceFoo only once", completions.items.filter { it.label == "instanceFoo" }, hasSize(1))
-        assertThat("Reports extensionFoo only once", completions.items.filter { it.label == "extensionFoo" }, hasSize(1))
+        assertThat("Reports instanceFoo only once", completions.items.filter { it.label.startsWith("instanceFoo") }, hasSize(1))
+        assertThat("Reports extensionFoo only once", completions.items.filter { it.label.startsWith("extensionFoo") }, hasSize(1))
     }
 
     @Test fun `find count extension function`() {
@@ -32,28 +32,28 @@ class InstanceMemberTest : SingleFileTestFixture("completions", "InstanceMember.
         val completions = languageServer.textDocumentService.completion(completionParams(file, 13, 16)).get().right!!
         val labels = completions.items.map { it.label }
 
-        assertThat(labels, hasItem("instanceFoo"))
+        assertThat(labels, hasItem(startsWith("instanceFoo")))
         // assertThat(labels, not(hasItem("extensionFoo"))) Kotlin will probably implement this later
-        assertThat(labels, hasItem("fooVar"))
-        assertThat(labels, not(hasItem("privateInstanceFoo")))
-        assertThat(labels, not(hasItem("getFooVar")))
-        assertThat(labels, not(hasItem("setFooVar")))
+        assertThat(labels, hasItem(startsWith("fooVar")))
+        assertThat(labels, not(hasItem(startsWith("privateInstanceFoo"))))
+        assertThat(labels, not(hasItem(startsWith("getFooVar"))))
+        assertThat(labels, not(hasItem(startsWith("setFooVar"))))
 
-        assertThat(completions.items.filter { it.label == "instanceFoo" }.firstOrNull(), hasProperty("insertText", equalTo("instanceFoo")))
+        assertThat(completions.items.filter { it.label.startsWith("instanceFoo") }.firstOrNull(), hasProperty("insertText", equalTo("instanceFoo")))
     }
 
     @Test fun `complete unqualified function reference`() {
         val completions = languageServer.textDocumentService.completion(completionParams(file, 17, 8)).get().right!!
         val labels = completions.items.map { it.label }
 
-        assertThat(labels, hasItem("findFunctionReference"))
+        assertThat(labels, hasItem(startsWith("findFunctionReference")))
     }
 
     @Test fun `complete a function name within a call`() {
         val completions = languageServer.textDocumentService.completion(completionParams(file, 22, 27)).get().right!!
         val labels = completions.items.map { it.label }
 
-        assertThat(labels, hasItem("findFunctionReference"))
+        assertThat(labels, hasItem(startsWith("findFunctionReference")))
         assertThat(labels, not(hasItem("instanceFoo")))
     }
 }
@@ -73,19 +73,20 @@ class FunctionScopeTest : SingleFileTestFixture("completions", "FunctionScope.kt
         val completions = languageServer.textDocumentService.completion(completionParams(file, 4, 10)).get().right!!
         val labels = completions.items.map { it.label }
 
+        println("ok lol"  + labels.toString())
         assertThat(labels, hasItem("anArgument"))
         assertThat(labels, hasItem("aLocal"))
         assertThat(labels, hasItem("aClassVal"))
-        assertThat(labels, hasItem("aClassFun"))
+        assertThat(labels, hasItem(startsWith("aClassFun")))
         assertThat(labels, hasItem("aCompanionVal"))
-        assertThat(labels, hasItem("aCompanionFun"))
+        assertThat(labels, hasItem(startsWith("aCompanionFun")))
 
         assertThat("Reports anArgument only once", completions.items.filter { it.label == "anArgument" }, hasSize(1))
         assertThat("Reports aLocal only once", completions.items.filter { it.label == "aLocal" }, hasSize(1))
         assertThat("Reports aClassVal only once", completions.items.filter { it.label == "aClassVal" }, hasSize(1))
-        assertThat("Reports aClassFun only once", completions.items.filter { it.label == "aClassFun" }, hasSize(1))
+        assertThat("Reports aClassFun only once", completions.items.filter { it.label.startsWith("aClassFun") }, hasSize(1))
         assertThat("Reports aCompanionVal only once", completions.items.filter { it.label == "aCompanionVal" }, hasSize(1))
-        assertThat("Reports aCompanionFun only once", completions.items.filter { it.label == "aCompanionFun" }, hasSize(1))
+        assertThat("Reports aCompanionFun only once", completions.items.filter { it.label.startsWith("aCompanionFun") }, hasSize(1))
     }
 }
 
@@ -109,7 +110,7 @@ class FillEmptyBodyTest : SingleFileTestFixture("completions", "FillEmptyBody.kt
         val completions = languageServer.textDocumentService.completion(completionParams(file, 3, 20)).get().right!!
         val labels = completions.items.map { it.label }
 
-        assertThat(labels, hasItem("bar"))
+        assertThat(labels, hasItem(startsWith("bar")))
     }
 }
 
@@ -127,7 +128,7 @@ class MiddleOfFunctionTest : SingleFileTestFixture("completions", "MiddleOfFunct
         val completions = languageServer.textDocumentService.completion(completionParams(file, 3, 11)).get().right!!
         val labels = completions.items.map { it.label }
 
-        assertThat(labels, hasItem("subSequence"))
+        assertThat(labels, hasItem(startsWith("subSequence")))
     }
 }
 
@@ -145,28 +146,28 @@ class CompleteStaticsTest : SingleFileTestFixture("completions", "Statics.kt") {
         val completions = languageServer.textDocumentService.completion(completionParams(file, 4, 16)).get().right!!
         val labels = completions.items.map { it.label }
 
-        assertThat(labels, hasItem("isNull"))
+        assertThat(labels, hasItem(startsWith("isNull")))
     }
 
     @Test fun `java static method reference`() {
         val completions = languageServer.textDocumentService.completion(completionParams(file, 7, 17)).get().right!!
         val labels = completions.items.map { it.label }
 
-        assertThat(labels, hasItem("isNull"))
+        assertThat(labels, hasItem(startsWith("isNull")))
     }
 
     @Test fun `object method`() {
         val completions = languageServer.textDocumentService.completion(completionParams(file, 5, 17)).get().right!!
         val labels = completions.items.map { it.label }
 
-        assertThat(labels, hasItem("objectFun"))
+        assertThat(labels, hasItem(startsWith("objectFun")))
     }
 
     @Test fun `companion object method`() {
         val completions = languageServer.textDocumentService.completion(completionParams(file, 6, 16)).get().right!!
         val labels = completions.items.map { it.label }
 
-        assertThat(labels, hasItem("companionFun"))
+        assertThat(labels, hasItem(startsWith("companionFun")))
     }
 }
 
@@ -175,9 +176,9 @@ class VisibilityTest : SingleFileTestFixture("completions", "Visibility.kt") {
         val completions = languageServer.textDocumentService.completion(completionParams(file, 3, 10)).get().right!!
         val labels = completions.items.map { it.label }
 
-        assertThat(labels, hasItems("privateThisFun", "protectedThisFun", "publicThisFun", "privateThisCompanionFun", "protectedThisCompanionFun", "publicThisCompanionFun", "privateTopLevelFun"))
-        assertThat(labels, hasItems("protectedSuperFun", "publicSuperFun", "protectedSuperCompanionFun", "publicSuperCompanionFun"))
-        assertThat(labels, not(hasItems("privateSuperFun", "privateSuperCompanionFun", "publicExtensionFun")))
+        assertThat(labels, hasItems(startsWith("privateThisFun"), startsWith("protectedThisFun"), startsWith("publicThisFun"), startsWith("privateThisCompanionFun"), startsWith("protectedThisCompanionFun"), startsWith("publicThisCompanionFun"), startsWith("privateTopLevelFun")))
+        assertThat(labels, hasItems(startsWith("protectedSuperFun"), startsWith("publicSuperFun"), startsWith("protectedSuperCompanionFun"), startsWith("publicSuperCompanionFun")))
+        assertThat(labels, not(hasItems(startsWith("privateSuperFun"), startsWith("privateSuperCompanionFun"), startsWith("publicExtensionFun"))))
     }
 }
 
@@ -210,7 +211,7 @@ class DoubleDotTest : SingleFileTestFixture("completions", "DoubleDot.kt") {
         val labels = completions.items.map { it.label }
 
         assertThat(labels, not(hasItem("chars")))
-        assertThat(labels, hasItem("anyMatch"))
+        assertThat(labels, hasItem(startsWith("anyMatch")))
     }
 }
 
@@ -219,7 +220,7 @@ class QuestionDotTest : SingleFileTestFixture("completions", "QuestionDot.kt") {
         val completions = languageServer.textDocumentService.completion(completionParams(file, 2, 8)).get().right!!
         val labels = completions.items.map { it.label }
 
-        assertThat(labels, hasItem("chars"))
+        assertThat(labels, hasItem(startsWith("chars")))
     }
 }
 
@@ -244,7 +245,7 @@ class EditCallTest : SingleFileTestFixture("completions", "EditCall.kt") {
         val completions = languageServer.textDocumentService.completion(completionParams(file, 2, 11)).get().right!!
         val labels = completions.items.map { it.label }
 
-        assertThat(labels, hasItem("println"))
-        assertThat(completions.items.filter { it.label == "println" }.firstOrNull(), hasProperty("insertText", equalTo("println")))
+        assertThat(labels, hasItem(startsWith("println")))
+        assertThat(completions.items.filter { it.label.startsWith("println") }.firstOrNull(), hasProperty("insertText", equalTo("println")))
     }
 }


### PR DESCRIPTION
Showing function/class name and now also list of parameters as provided to us in completion list. More of a preference thing, i like that one can see all differences in the overloads at a glance unlike previously where one would only see the parameter list of the selected completion.
Tested with functions/methods and class constructors

Before:
![before](https://files.gitter.im/fwcd-projects/KotlinLanguageServer/wRRd/image.png)

After:
![after](https://files.gitter.im/fwcd-projects/KotlinLanguageServer/pJ5v/image.png)