### PR TITLE
Fix autocomplete for enums with companion objects

### DIFF
--- a/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -182,7 +182,7 @@ private fun completeMembers(file: CompiledFile, cursor: Int, receiverExpr: KtExp
             val members = receiverType.memberScope.getContributedDescriptors().asSequence()
             val extensions = extensionFunctions(lexicalScope).filter { isExtensionFor(receiverType, it) }
             descriptors = members + extensions
-            if (!DescriptorUtils.isCompanionObject(TypeUtils.getClassDescriptor(receiverType))) {
+            if (!isCompanionOfEnum(receiverType)) {
                 return descriptors
             }
         }
@@ -198,6 +198,15 @@ private fun completeMembers(file: CompiledFile, cursor: Int, receiverExpr: KtExp
 
     LOG.debug("Can't find member scope for {}", receiverExpr.text)
     return emptySequence()
+}
+
+private fun isCompanionOfEnum(kotlinType: KotlinType): Boolean {
+    val classDescriptor = TypeUtils.getClassDescriptor(kotlinType)
+    val isCompanion = DescriptorUtils.isCompanionObject(classDescriptor)
+    if (!isCompanion) {
+        return false
+    }
+    return DescriptorUtils.isEnumClass(classDescriptor?.containingDeclaration)
 }
 
 private fun findPartialIdentifier(file: CompiledFile, cursor: Int): String {

--- a/src/test/kotlin/org/javacs/kt/CompletionsTest.kt
+++ b/src/test/kotlin/org/javacs/kt/CompletionsTest.kt
@@ -249,3 +249,12 @@ class EditCallTest : SingleFileTestFixture("completions", "EditCall.kt") {
         assertThat(completions.items.filter { it.label.startsWith("println") }.firstOrNull(), hasProperty("insertText", equalTo("println")))
     }
 }
+
+class EnumWithCompanionObjectTest : SingleFileTestFixture("completions", "Enum.kt") {
+    @Test fun `enum with companion object`() {
+        val completions = languageServer.textDocumentService.completion(completionParams(file, 9, 15)).get().right!!
+        val labels = completions.items.map { it.label }
+
+        assertThat(labels, hasItem("ILLEGAL"))
+    }
+}

--- a/src/test/resources/completions/Enum.kt
+++ b/src/test/resources/completions/Enum.kt
@@ -1,0 +1,10 @@
+enum class TokenType {
+    ILLEGAL;
+
+    companion object {
+    }
+}
+
+fun tokenTypeFunc() {
+    TokenType.
+}


### PR DESCRIPTION
Fix for https://github.com/fwcd/KotlinLanguageServer/issues/63

The loading of descriptors was stopping after looking at the companion object when it should have also looked at the enum for more autocomplete options.  This is my first PR here so feel free to recommend a better implementation.