### PR TITLE
provide accurate completions when triggered from the middle of an instance method

### DIFF
--- a/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -104,6 +104,8 @@ private fun completableElement(file: CompiledFile, cursor: Int): KtElement? {
             el as? KtQualifiedExpression ?: el.parent as? KtQualifiedExpression ?:
             // something::?
             el as? KtCallableReferenceExpression ?: el.parent as? KtCallableReferenceExpression ?:
+            // something.foo() with cursor in the method
+            el.parent?.parent as? KtQualifiedExpression ?:
             // ?
             el as? KtNameReferenceExpression
 }

--- a/src/test/kotlin/org/javacs/kt/CompletionsTest.kt
+++ b/src/test/kotlin/org/javacs/kt/CompletionsTest.kt
@@ -56,6 +56,13 @@ class InstanceMemberTest : SingleFileTestFixture("completions", "InstanceMember.
         assertThat(labels, hasItem(startsWith("findFunctionReference")))
         assertThat(labels, not(hasItem("instanceFoo")))
     }
+
+    @Test fun `find completions on letters of method call`() {
+        val completions = languageServer.textDocumentService.completion(completionParams(file, 26, 26)).get().right!!
+        val labels = completions.items.map { it.label }
+
+        assertThat(labels, hasItems(startsWith("instanceFee"), startsWith("instanceFoo")))
+    }
 }
 
 class InstanceMembersJava : SingleFileTestFixture("completions", "InstanceMembersJava.kt") {

--- a/src/test/resources/completions/InstanceMember.kt
+++ b/src/test/resources/completions/InstanceMember.kt
@@ -22,8 +22,13 @@ private fun completeIdentifierInsideCall() {
     instance.instanceFoo(f)
 }
 
+private fun findCompletionsForLettersInFullMethod() {
+    SomeClass().instanceFoo()
+}
+
 private class SomeClass {
     fun instanceFoo() = "Foo"
+    fun instanceFee() = "Fee"
     private fun privateInstanceFoo() = "Foo"
     var fooVar = 1
 }


### PR DESCRIPTION
(Partly) Fixes https://github.com/fwcd/KotlinLanguageServer/issues/75

Referencing the test:
if there is a call `SomeClass().instanceFoo()` and you place the cursor right after the `F` in `instanceFoo`, you should get the options of `instanceFoo` and `instanceFee` instead of nothing.

Is there any documentation on these Kotlin classes because I have no idea if I'm doing this right at all? The only thing I was judging by was debugging and calling `el.text`, `el.parent.text`, etc and saw that `el.text` returns `instanceFoo`, `el.parent.text` returns `instanceFoo()` but `el.parent.parent.text` returns `SomeClass().instanceFoo()`.  I don't know if this will fix every expression.

I'm guessing a possible refactor would be checking if `el` has any ancestor that is a `KtQualifiedExpression` but not sure what other cases are unhandled by this change.