### PR TITLE
Fix an issue when trying to resolve an non source file

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -111,7 +111,7 @@ class SourceFiles(private val sp: SourcePath) {
         try {
             content = Files.readAllLines(file).joinToString("\n")
         } catch(exception:Exception) {
-            LOG.debug("Exception while parsing source file : ${file.toFile().absolutePath}")
+            LOG.warn("Exception while parsing source file : ${file.toFile().absolutePath}")
         }
 
         return SourceVersion(content, -1)

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -110,7 +110,7 @@ class SourceFiles(private val sp: SourcePath) {
 
         try {
             content = Files.readAllLines(file).joinToString("\n")
-        } catch(exception:Exception) {
+        } catch(exception: IOException) {
             LOG.warn("Exception while parsing source file : ${file.toFile().absolutePath}")
         }
 

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -106,7 +106,13 @@ class SourceFiles(private val sp: SourcePath) {
     private fun readFromDisk(file: Path): SourceVersion? {
         if (!Files.exists(file)) return null
 
-        val content = Files.readAllLines(file).joinToString("\n")
+        var content = ""
+
+        try {
+            content = Files.readAllLines(file).joinToString("\n")
+        } catch(exception:Exception) {
+            LOG.debug("Exception while parsing source file : ${file.toFile().absolutePath}")
+        }
 
         return SourceVersion(content, -1)
     }


### PR DESCRIPTION
It seems that in some cases the plugin is trying to resolve files who
are not part of the workspace, due to either their temporary nature, or
other IDE or tool file.

In my case, it was trying to resole files from the vim .undodir
directory, was failing to parse those files due to their binary nature,
and the whole sourceset resolution was failing in consequence.

To avoid that issue add a try catch around the file reading method to
ensure exception are not fired, and the resolution does not break.