### PR TITLE
Organize FindClassPath and add classpath resolution from shell script

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/classpath/BackupClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/BackupClassPathResolver.kt
@@ -1,0 +1,93 @@
+package org.javacs.kt.classpath
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.function.BiPredicate
+import org.javacs.kt.util.firstNonNull
+import org.javacs.kt.util.tryResolving
+import java.nio.file.Paths
+
+/** Backup classpath that just tries to find Kotlin. */
+object BackupClassPathResolver : ClassPathResolver {
+    override val classpath: Set<Path> get() = findKotlinStdlib()?.let { setOf(it) }.orEmpty()
+}
+
+fun findKotlinStdlib(): Path? = findLocalArtifact("org.jetbrains.kotlin", "kotlin-stdlib")
+
+private fun findLocalArtifact(group: String, artifact: String) = firstNonNull<Path>(
+    { tryResolving("$artifact using Maven") { tryFindingLocalArtifactUsing(group, artifact, findLocalArtifactDirUsingMaven(group, artifact)) } },
+    { tryResolving("$artifact using Gradle") { tryFindingLocalArtifactUsing(group, artifact, findLocalArtifactDirUsingGradle(group, artifact)) } }
+)
+
+private fun tryFindingLocalArtifactUsing(@Suppress("UNUSED_PARAMETER") group: String, artifact: String, artifactDirResolution: LocalArtifactDirectoryResolution): Path? {
+    val isCorrectArtifact = BiPredicate<Path, BasicFileAttributes> { file, _ ->
+        val name = file.fileName.toString()
+        when (artifactDirResolution.buildTool) {
+            "Maven" -> {
+                val version = file.parent.fileName.toString()
+                val expected = "${artifact}-${version}.jar"
+                name == expected
+            }
+            else -> name.startsWith(artifact) && name.endsWith(".jar")
+        }
+    }
+    return Files.list(artifactDirResolution.artifactDir)
+        .sorted(::compareVersions)
+        .findFirst()
+        .orElse(null)
+        ?.let {
+            Files.find(artifactDirResolution.artifactDir, 3, isCorrectArtifact)
+                .findFirst()
+                .orElse(null)
+        }
+}
+
+private data class LocalArtifactDirectoryResolution(val artifactDir: Path?, val buildTool: String)
+
+private fun Path.existsOrNull() =
+    if (Files.exists(this)) this else null
+
+private fun findLocalArtifactDirUsingMaven(group: String, artifact: String) =
+    LocalArtifactDirectoryResolution(mavenHome.resolve("repository")
+        ?.resolve(group.replace('.', File.separatorChar))
+        ?.resolve(artifact)
+        ?.existsOrNull(), "Maven")
+
+private fun findLocalArtifactDirUsingGradle(group: String, artifact: String) =
+    LocalArtifactDirectoryResolution(gradleCaches
+        ?.resolve(group)
+        ?.resolve(artifact)
+        ?.existsOrNull(), "Gradle")
+
+
+private val gradleHome = userHome.resolve(".gradle")
+
+// TODO: Resolve the gradleCaches dynamically instead of hardcoding this path
+private val gradleCaches by lazy {
+    gradleHome.resolve("caches")
+        .resolveStartingWith("modules")
+        .resolveStartingWith("files")
+}
+
+private fun Path.resolveStartingWith(prefix: String) = Files.list(this).filter { it.fileName.toString().startsWith(prefix) }.findFirst().orElse(null)
+
+private fun compareVersions(left: Path, right: Path): Int {
+    val leftVersion = extractVersion(left)
+    val rightVersion = extractVersion(right)
+
+    for (i in 0 until Math.min(leftVersion.size, rightVersion.size)) {
+        val leftRev = leftVersion[i].reversed()
+        val rightRev = rightVersion[i].reversed()
+        val compare = leftRev.compareTo(rightRev)
+        if (compare != 0)
+            return -compare
+    }
+
+    return -leftVersion.size.compareTo(rightVersion.size)
+}
+private fun extractVersion(artifactVersionDir: Path): List<String> {
+    return artifactVersionDir.toString().split(".")
+}
+

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/FindClassPath.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/FindClassPath.kt
@@ -1,277 +1,60 @@
 package org.javacs.kt.classpath
 
-import java.util.logging.Level
 import org.javacs.kt.LOG
-import org.javacs.kt.util.winCompatiblePathOf
-import org.javacs.kt.util.tryResolving
-import org.javacs.kt.util.firstNonNull
-import org.javacs.kt.util.KotlinLSException
 import java.io.File
-import java.io.IOException
-import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.nio.file.attribute.BasicFileAttributes
-import java.util.stream.Collectors
-import java.util.function.BiPredicate
-import java.util.Comparator
-import java.util.concurrent.TimeUnit
 
 fun findClassPath(workspaceRoots: Collection<Path>): Set<Path> {
-    return ensureStdlibInPaths(
-        workspaceRoots
-            .flatMap { projectFiles(it) }
-            .flatMap { readProjectFile(it) }
-            .toSet()
-    ).ifEmpty(::backupClassPath)
+    val workspace = WithStdlibResolver(
+        workspaceRoots.asSequence()
+            .flatMap(::workspaceResolvers)
+            .fold(ClassPathResolver.empty) { accum, next -> accum + next }
+
+    )
+    return workspace.or(BackupClassPathResolver).classpath
 }
 
-private fun ensureStdlibInPaths(paths: Set<Path>): Set<Path> {
-    // Ensure that there is exactly one kotlin-stdlib present, and/or exactly one of kotlin-stdlib-common, -jdk8, etc.
-    val isStdlib: ((Path) -> Boolean) = { it.toString().contains("kotlin-stdlib") }
+/** A source for creating class paths */
+internal interface ClassPathResolver {
+    val classpath: Set<Path>
 
-    val linkedStdLibs = paths.filter(isStdlib)
-        .mapNotNull { StdLibItem.from(it) }
-        .groupBy { it.key }
-        .map { candidates ->
-            // For each "kotlin-stdlib-blah", use the newest.  This may not be correct behavior if the project has lots of
-            // conflicting dependencies, but in general should get enough of the stdlib loaded that we can display errors
-            
-            candidates.value.sortedWith(
-                compareByDescending<StdLibItem> { it.major } then
-                    compareByDescending { it.minor } then
-                        compareByDescending { it.patch }
-            ).first().path
-        }
-
-    val stdlibs = if (linkedStdLibs.isNotEmpty()) {
-        linkedStdLibs
-    } else {
-        findKotlinStdlib()?.let { listOf(it) } ?: listOf()
-    }
-
-    return paths.filterNot(isStdlib).union(stdlibs)
-}
-
-private data class StdLibItem(
-    val key : String,
-    val major : Int,
-    val minor: Int,
-    val patch : Int,
-    val path: Path
-) {
     companion object {
-        // Matches names like: "kotlin-stdlib-jdk7-1.2.51.jar"
-        val parser = Regex("""(kotlin-stdlib(-[^-]+)?)-(\d+)\.(\d+)\.(\d+)\.jar""")
 
-        fun from(path: Path) : StdLibItem? {
-            return parser.matchEntire(path.fileName.toString())?.let { match ->
-                StdLibItem(
-                    key = match.groups[1]?.value ?: match.groups[0]?.value!!,
-                    major = match.groups[3]?.value?.toInt() ?: 0,
-                    minor = match.groups[4]?.value?.toInt() ?: 0,
-                    patch = match.groups[5]?.value?.toInt() ?: 0,
-                    path = path
-                )
-            }
+        /** A default empty classpath implementation */
+        val empty = object : ClassPathResolver {
+            override val classpath = emptySet<Path>()
         }
     }
 }
 
-private fun backupClassPath() =
-    listOfNotNull(findKotlinStdlib()).toSet()
-
-private fun projectFiles(workspaceRoot: Path): Set<Path> {
-    return Files.walk(workspaceRoot)
-            .filter { isMavenBuildFile(it) || isGradleBuildFile(it) }
-            .collect(Collectors.toSet())
-}
-
-private fun readProjectFile(file: Path): Set<Path> {
-    if (isMavenBuildFile(file)) {
-        // Project uses a Maven model
-        return readPom(file)
-    } else if (isGradleBuildFile(file)) {
-        // Project uses a Gradle model
-        return readBuildGradle(file)
-    } else {
-        throw IllegalArgumentException("$file is not a valid project configuration file (pom.xml or build.gradle)")
-    }
-}
-
-private fun isMavenBuildFile(file: Path) = file.endsWith("pom.xml")
-
-private fun isGradleBuildFile(file: Path) = file.endsWith("build.gradle") || file.endsWith("build.gradle.kts")
-
-private fun readPom(pom: Path): Set<Path> {
-    val mavenOutput = generateMavenDependencyList(pom)
-    val artifacts = mavenOutput?.let(::readMavenDependencyList) ?: throw KotlinLSException("No artifacts could be read from $pom")
-
-    when {
-        artifacts.isEmpty() -> LOG.warn("No artifacts found in {}", pom)
-        artifacts.size < 5 -> LOG.info("Found {} in {}", artifacts, pom)
-        else -> LOG.info("Found {} artifacts in {}", artifacts.size, pom)
+/** Combines two classpath resolvers */
+internal operator fun ClassPathResolver.plus(other: ClassPathResolver): ClassPathResolver =
+    object : ClassPathResolver {
+        override val classpath = this@plus.classpath + other.classpath
     }
 
-    return artifacts.mapNotNull { findMavenArtifact(it, false) }.toSet()
-}
-
-private fun generateMavenDependencyList(pom: Path): Path? {
-    val mavenOutput = Files.createTempFile("deps", ".txt")
-    val workingDirectory = pom.toAbsolutePath().parent.toFile()
-    val cmd = "${mvnCommand()} dependency:list -DincludeScope=test -DoutputFile=$mavenOutput"
-    LOG.info("Run {} in {}", cmd, workingDirectory)
-    val process = Runtime.getRuntime().exec(cmd, null, workingDirectory)
-
-    process.inputStream.bufferedReader().use { reader ->
-        while (process.isAlive()) {
-            val line = reader.readLine()?.trim()
-            if (line == null) break
-            if ((line.length > 0) && !line.startsWith("Progress")) {
-                LOG.info("Maven: {}", line)
-            }
-        }
+/** Uses the left-hand classpath if not empty, otherwise uses the right */
+internal fun ClassPathResolver.or(other: ClassPathResolver): ClassPathResolver =
+    object : ClassPathResolver {
+        override val classpath = this@or.classpath.takeIf { it.isNotEmpty() } ?: other.classpath
     }
 
-    return mavenOutput
-}
+/** Searches the workspace for all files that could provide classpath info */
+private fun workspaceResolvers(workspaceRoot: Path): Sequence<ClassPathResolver> =
+    workspaceRoot.toFile().walk().mapNotNull { asClassPathProvider(it.toPath()) }
 
-private val artifact = ".*:.*:.*:.*:.*".toRegex()
+/** Tries to create a classpath resolver from a file using as many sources as possible */
+private fun asClassPathProvider(path: Path): ClassPathResolver? =
+    MavenClassPathResolver.maybeCreate(path) ?: GradleClassPathResolver.maybeCreate(path)
 
-private fun readMavenDependencyList(mavenOutput: Path): Set<Artifact> =
-        mavenOutput.toFile()
-                .readLines()
-                .filter { it.matches(artifact) }
-                .map { parseArtifact(it) }
-                .toSet()
+internal val userHome = Paths.get(System.getProperty("user.home"))
 
-fun parseArtifact(rawArtifact: String, version: String? = null): Artifact {
-    val parts = rawArtifact.trim().split(':')
+internal val mavenHome = userHome.resolve(".m2")
 
-    return when (parts.size) {
-        3 -> Artifact(parts[0], parts[1], version ?: parts[2])
-        5 -> Artifact(parts[0], parts[1], version ?: parts[3])
-        else -> throw IllegalArgumentException("$rawArtifact is not a properly formed Maven/Gradle artifact")
-    }
-}
+internal fun isOSWindows() = (File.separatorChar == '\\')
 
-data class Artifact(val group: String, val artifact: String, val version: String) {
-    override fun toString() = "$group:$artifact:$version"
-}
-
-private val userHome = Paths.get(System.getProperty("user.home"))
-val mavenHome = userHome.resolve(".m2")
-val gradleHome = userHome.resolve(".gradle")
-// TODO: Resolve the gradleCaches dynamically instead of hardcoding this path
-val gradleCaches by lazy {
-    gradleHome.resolve("caches")
-            .resolveStartingWith("modules")
-            .resolveStartingWith("files")
-}
-
-private fun Path.resolveStartingWith(prefix: String) = Files.list(this).filter { it.fileName.toString().startsWith(prefix) }.findFirst().orElse(null)
-
-fun findKotlinStdlib(): Path? {
-    return findLocalArtifact("org.jetbrains.kotlin", "kotlin-stdlib")
-}
-
-private data class LocalArtifactDirectoryResolution(val artifactDir: Path?, val buildTool: String)
-
-private fun findLocalArtifact(group: String, artifact: String) = firstNonNull<Path>(
-        { tryResolving("$artifact using Maven") { tryFindingLocalArtifactUsing(group, artifact, findLocalArtifactDirUsingMaven(group, artifact)) } },
-        { tryResolving("$artifact using Gradle") { tryFindingLocalArtifactUsing(group, artifact, findLocalArtifactDirUsingGradle(group, artifact)) } }
-)
-
-private fun tryFindingLocalArtifactUsing(@Suppress("UNUSED_PARAMETER") group: String, artifact: String, artifactDirResolution: LocalArtifactDirectoryResolution): Path? {
-    val isCorrectArtifact = BiPredicate<Path, BasicFileAttributes> { file, _ ->
-        val name = file.fileName.toString()
-        when (artifactDirResolution.buildTool) {
-            "Maven" -> {
-                val version = file.parent.fileName.toString()
-                val expected = "${artifact}-${version}.jar"
-                name == expected
-            }
-            else -> name.startsWith(artifact) && name.endsWith(".jar")
-        }
-    }
-    return Files.list(artifactDirResolution.artifactDir)
-            .sorted(::compareVersions)
-            .findFirst()
-            .orElse(null)
-            ?.let {
-                Files.find(artifactDirResolution.artifactDir, 3, isCorrectArtifact)
-                    .findFirst()
-                    .orElse(null)
-            }
-}
-
-private fun Path.existsOrNull() =
-        if (Files.exists(this)) this else null
-
-private fun findLocalArtifactDirUsingMaven(group: String, artifact: String) =
-        LocalArtifactDirectoryResolution(mavenHome.resolve("repository")
-            ?.resolve(group.replace('.', File.separatorChar))
-            ?.resolve(artifact)
-            ?.existsOrNull(), "Maven")
-
-private fun findLocalArtifactDirUsingGradle(group: String, artifact: String) =
-        LocalArtifactDirectoryResolution(gradleCaches
-            ?.resolve(group)
-            ?.resolve(artifact)
-            ?.existsOrNull(), "Gradle")
-
-private fun compareVersions(left: Path, right: Path): Int {
-    val leftVersion = extractVersion(left)
-    val rightVersion = extractVersion(right)
-
-    for (i in 0 until Math.min(leftVersion.size, rightVersion.size)) {
-        val leftRev = leftVersion[i].reversed()
-        val rightRev = rightVersion[i].reversed()
-        val compare = leftRev.compareTo(rightRev)
-        if (compare != 0)
-            return -compare
-    }
-
-    return -leftVersion.size.compareTo(rightVersion.size)
-}
-
-private fun extractVersion(artifactVersionDir: Path): List<String> {
-    return artifactVersionDir.toString().split(".")
-}
-
-private fun findMavenArtifact(a: Artifact, source: Boolean): Path? {
-    val result = mavenHome.resolve("repository")
-            .resolve(a.group.replace('.', File.separatorChar))
-            .resolve(a.artifact)
-            .resolve(a.version)
-            .resolve(mavenJarName(a, source))
-
-    if (Files.exists(result))
-        return result
-    else {
-        LOG.warn("Couldn't find {} in {}", a, result)
-        return null
-    }
-}
-
-private fun mavenJarName(a: Artifact, source: Boolean) =
-        if (source) "${a.artifact}-${a.version}-sources.jar"
-        else "${a.artifact}-${a.version}.jar"
-
-private var cacheMvnCommand: Path? = null
-
-private fun mvnCommand(): Path {
-    if (cacheMvnCommand == null)
-        cacheMvnCommand = doMvnCommand()
-
-    return cacheMvnCommand!!
-}
-
-fun isOSWindows() = (File.separatorChar == '\\')
-
-private fun doMvnCommand() = findCommandOnPath("mvn")
-
-fun findCommandOnPath(name: String): Path? =
+internal fun findCommandOnPath(name: String): Path? =
         if (isOSWindows()) windowsCommand(name)
         else unixCommand(name)
 

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
@@ -1,0 +1,97 @@
+package org.javacs.kt.classpath
+
+import org.javacs.kt.LOG
+import org.javacs.kt.util.KotlinLSException
+import java.nio.file.Path
+import java.nio.file.Files
+import java.io.File
+
+/** Resolver for reading maven dependencies */
+internal class MavenClassPathResolver private constructor(private val pom: Path) : ClassPathResolver {
+
+    override val classpath: Set<Path> get() {
+        val mavenOutput = generateMavenDependencyList(pom)
+        val artifacts = mavenOutput?.let(::readMavenDependencyList) ?: throw KotlinLSException("No artifacts could be read from $pom")
+
+        when {
+            artifacts.isEmpty() -> LOG.warn("No artifacts found in {}", pom)
+            artifacts.size < 5 -> LOG.info("Found {} in {}", artifacts, pom)
+            else -> LOG.info("Found {} artifacts in {}", artifacts.size, pom)
+        }
+
+        return artifacts.mapNotNull { findMavenArtifact(it, false) }.toSet()
+    }
+
+    companion object {
+
+        /** Create a maven resolver if a file is a pom */
+        fun maybeCreate(file: Path): MavenClassPathResolver? =
+            file?.takeIf { it.endsWith("pom.xml") }?.let { MavenClassPathResolver(it) }
+    }
+}
+
+private val artifact = ".*:.*:.*:.*:.*".toRegex()
+
+private fun readMavenDependencyList(mavenOutput: Path): Set<Artifact> =
+    mavenOutput.toFile()
+        .readLines()
+        .filter { it.matches(artifact) }
+        .map { parseArtifact(it) }
+        .toSet()
+
+private fun findMavenArtifact(a: Artifact, source: Boolean): Path? {
+    val result = mavenHome.resolve("repository")
+        .resolve(a.group.replace('.', File.separatorChar))
+        .resolve(a.artifact)
+        .resolve(a.version)
+        .resolve(mavenJarName(a, source))
+
+    if (Files.exists(result))
+        return result
+    else {
+        LOG.warn("Couldn't find {} in {}", a, result)
+        return null
+    }
+}
+
+private fun mavenJarName(a: Artifact, source: Boolean) =
+    if (source) "${a.artifact}-${a.version}-sources.jar"
+    else "${a.artifact}-${a.version}.jar"
+
+private fun generateMavenDependencyList(pom: Path): Path? {
+    val mavenOutput = Files.createTempFile("deps", ".txt")
+    val workingDirectory = pom.toAbsolutePath().parent.toFile()
+    val cmd = "${mvnCommand} dependency:list -DincludeScope=test -DoutputFile=$mavenOutput"
+    LOG.info("Run {} in {}", cmd, workingDirectory)
+    val process = Runtime.getRuntime().exec(cmd, null, workingDirectory)
+
+    process.inputStream.bufferedReader().use { reader ->
+        while (process.isAlive()) {
+            val line = reader.readLine()?.trim()
+            if (line == null) break
+            if ((line.length > 0) && !line.startsWith("Progress")) {
+                LOG.info("Maven: {}", line)
+            }
+        }
+    }
+
+    return mavenOutput
+}
+
+private val mvnCommand: Path by lazy {
+    requireNotNull(findCommandOnPath("mvn")) { "Unable to find the 'mvn' command" }
+}
+
+fun parseArtifact(rawArtifact: String, version: String? = null): Artifact {
+    val parts = rawArtifact.trim().split(':')
+
+    return when (parts.size) {
+        3 -> Artifact(parts[0], parts[1], version ?: parts[2])
+        5 -> Artifact(parts[0], parts[1], version ?: parts[3])
+        else -> throw IllegalArgumentException("$rawArtifact is not a properly formed Maven/Gradle artifact")
+    }
+}
+
+data class Artifact(val group: String, val artifact: String, val version: String) {
+    override fun toString() = "$group:$artifact:$version"
+}

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/ShellClassPathFinder.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/ShellClassPathFinder.kt
@@ -1,0 +1,46 @@
+package org.javacs.kt.classpath
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import org.javacs.kt.LOG
+
+/** Executes a shell script to determine the classpath */
+internal class ShellClassPathResolver(
+    private val script: Path,
+    private val workingDir: Path? = null
+) : ClassPathResolver {
+
+    override val classpath: Set<Path> get() {
+        val workingDirectory = workingDir?.toFile() ?: script.toAbsolutePath().parent.toFile()
+        val cmd = script.toString()
+        LOG.info("Run {} in {}", cmd, workingDirectory)
+        val process = Runtime.getRuntime().exec(cmd, null, workingDirectory)
+
+        return process.inputStream.bufferedReader().readText()
+            .split(':')
+            .asSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .map { Paths.get(it) }
+            .toSet()
+    }
+
+    companion object {
+
+        /** Create a maven resolver if a file is a pom */
+        fun maybeCreate(file: Path): ShellClassPathResolver? =
+            file.takeIf { it.endsWith("kotlinLspClasspath.sh") }?.let { ShellClassPathResolver(it) }
+
+        /** The root directory for config files */
+        private val globalConfigRoot: Path =
+            System.getenv("XDG_CONFIG_HOME")?.let { Paths.get(it) } ?: userHome.resolve(".config")
+
+        /** Returns the ShellClassPathResolver for the global home directory shell script */
+        fun global(workingDir: Path?): ClassPathResolver =
+            globalConfigRoot.resolve("KotlinLanguageServer").resolve("classpath.sh")
+                .takeIf { Files.exists(it) }
+                ?.let { ShellClassPathResolver(it, workingDir) }
+                ?: ClassPathResolver.empty
+    }
+}

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/WithStdlibResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/WithStdlibResolver.kt
@@ -1,0 +1,60 @@
+package org.javacs.kt.classpath
+
+import java.nio.file.Path
+
+/** A classpath resolver that ensures another resolver contains the stdlib */
+internal class WithStdlibResolver(private val wrap: ClassPathResolver) : ClassPathResolver {
+    override val classpath: Set<Path> get() {
+        val paths = wrap.classpath
+
+        // Ensure that there is exactly one kotlin-stdlib present, and/or exactly one of kotlin-stdlib-common, -jdk8, etc.
+        val isStdlib: ((Path) -> Boolean) = { it.toString().contains("kotlin-stdlib") }
+
+        val linkedStdLibs = paths.filter(isStdlib)
+            .mapNotNull { StdLibItem.from(it) }
+            .groupBy { it.key }
+            .map { candidates ->
+                // For each "kotlin-stdlib-blah", use the newest.  This may not be correct behavior if the project has lots of
+                // conflicting dependencies, but in general should get enough of the stdlib loaded that we can display errors
+
+                candidates.value.sortedWith(
+                    compareByDescending<StdLibItem> { it.major } then
+                        compareByDescending { it.minor } then
+                        compareByDescending { it.patch }
+                ).first().path
+            }
+
+        val stdlibs = if (linkedStdLibs.isNotEmpty()) {
+            linkedStdLibs
+        } else {
+            findKotlinStdlib()?.let { listOf(it) } ?: listOf()
+        }
+
+        return paths.filterNot(isStdlib).union(stdlibs)
+    }
+}
+
+private data class StdLibItem(
+    val key : String,
+    val major : Int,
+    val minor: Int,
+    val patch : Int,
+    val path: Path
+) {
+    companion object {
+        // Matches names like: "kotlin-stdlib-jdk7-1.2.51.jar"
+        val parser = Regex("""(kotlin-stdlib(-[^-]+)?)-(\d+)\.(\d+)\.(\d+)\.jar""")
+
+        fun from(path: Path) : StdLibItem? {
+            return parser.matchEntire(path.fileName.toString())?.let { match ->
+                StdLibItem(
+                    key = match.groups[1]?.value ?: match.groups[0]?.value!!,
+                    major = match.groups[3]?.value?.toInt() ?: 0,
+                    minor = match.groups[4]?.value?.toInt() ?: 0,
+                    patch = match.groups[5]?.value?.toInt() ?: 0,
+                    path = path
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview

 I work with a number of repos that use a non-public, proprietary dependency resolution system. To get the language server to find dependencies, I needed a way to run a simple shell command that just returned a colon delimited list of jars. While I was in there, I also did some organization to make this section of code less monolithic.

### Commit 1: Organization

My first commit adds a new interface, `ClassPathResolver`. Its got one property: `classpaths`. I could have left it as a set of methods, but using an interface adds more semantic meaning.

I then split the existing code into separate files:

1. `GradleClassPathResolver`: All of the existing gradle resolution logic
2. `MavenClassPathResolver`: All of the existing maven resolution logic
3. `WithStdlibResolver`: Existing logic that adds the stdlib to to another `ClassPathResolver` if it isn't already included
4. `BackupClassPathResolver`: Existing logic that looks up the Kotlin stdlib as a backup if the other resolvers failed

### Commit 2: Classpath resolution from  shell script

This adds a new `ClassPathResolver` that looks for a shell script and calls it. It looks in two places:

1. `$workingDir/kotlinLspClasspath.sh` -- this allows for scripts that are local to a repo
2. `$XDG_CONFIG_HOME/KotlinLanguageServer/classpath.sh` -- this allows a user to install a global script that applies to all repos

It expects those files to print a colon delimited list of jars, which are then added to the classpath.