### PR TITLE
Add snippet configuration support

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,15 +58,20 @@
         "configuration": {
             "title": "Kotlin",
             "properties": {
+                "kotlin.languageServer.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Specifies whether the language server should be used. When enabled the extension will provide code completions and linting, otherwise just syntax highlighting. Might require a reload to apply."
+                },
                 "kotlin.debounceTime": {
                     "type": "integer",
                     "default": 250,
                     "description": "[DEBUG] Specifies the debounce time limit. Lower to increase responsiveness at the cost of possibile stability issues"
                 },
-                "kotlin.languageServer.enabled": {
+                "kotlin.snippetsEnabled": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Specifies whether the language server should be used. When enabled the extension will provide code completions and linting, otherwise just syntax highlighting. Might require a reload to apply."
+                    "description": "Specifies whether code completion should provide snippets (true) or plain-text items (false)"
                 }
             }
         }

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -1,5 +1,6 @@
 package org.javacs.kt
 
 public class Configuration(
-    var debounceTime: Long = 250L
+    var debounceTime: Long = 250L,
+    var snippetsEnabled: Boolean = true
 )

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -40,21 +40,24 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware {
     }
 
     override fun initialize(params: InitializeParams): CompletableFuture<InitializeResult> {
-        val capabilities = ServerCapabilities()
-        capabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental)
-        capabilities.workspace = WorkspaceServerCapabilities()
-        capabilities.workspace.workspaceFolders = WorkspaceFoldersOptions()
-        capabilities.workspace.workspaceFolders.supported = true
-        capabilities.workspace.workspaceFolders.changeNotifications = Either.forRight(true)
-        capabilities.hoverProvider = true
-        capabilities.completionProvider = CompletionOptions(false, listOf("."))
-        capabilities.signatureHelpProvider = SignatureHelpOptions(listOf("(", ","))
-        capabilities.definitionProvider = true
-        capabilities.documentSymbolProvider = true
-        capabilities.workspaceSymbolProvider = true
-        capabilities.referencesProvider = true
-        capabilities.codeActionProvider = true
-        capabilities.executeCommandProvider = ExecuteCommandOptions(ALL_COMMANDS)
+        val serverCapabilities = ServerCapabilities()
+        serverCapabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental)
+        serverCapabilities.workspace = WorkspaceServerCapabilities()
+        serverCapabilities.workspace.workspaceFolders = WorkspaceFoldersOptions()
+        serverCapabilities.workspace.workspaceFolders.supported = true
+        serverCapabilities.workspace.workspaceFolders.changeNotifications = Either.forRight(true)
+        serverCapabilities.hoverProvider = true
+        serverCapabilities.completionProvider = CompletionOptions(false, listOf("."))
+        serverCapabilities.signatureHelpProvider = SignatureHelpOptions(listOf("(", ","))
+        serverCapabilities.definitionProvider = true
+        serverCapabilities.documentSymbolProvider = true
+        serverCapabilities.workspaceSymbolProvider = true
+        serverCapabilities.referencesProvider = true
+        serverCapabilities.codeActionProvider = true
+        serverCapabilities.executeCommandProvider = ExecuteCommandOptions(ALL_COMMANDS)
+
+        val clientCapabilities = params.capabilities
+        config.snippetsEnabled = clientCapabilities?.textDocument?.completion?.completionItem?.snippetSupport ?: false
 
         if (params.rootUri != null) {
             LOG.info("Adding workspace {} to source path", params.rootUri)
@@ -65,7 +68,7 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware {
             classPath.addWorkspaceRoot(root)
         }
 
-        return completedFuture(InitializeResult(capabilities))
+        return completedFuture(InitializeResult(serverCapabilities))
     }
 
     override fun getWorkspaceService(): KotlinWorkspaceService {

--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -115,7 +115,7 @@ class KotlinTextDocumentService(
             LOG.info("Completing at {}", describePosition(position))
 
             val (file, cursor) = recover(position, false)
-            val completions = completions(file, cursor)
+            val completions = completions(file, cursor, config.snippetsEnabled)
 
             LOG.info("Found {} items", completions.items.size)
 

--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -79,8 +79,12 @@ class KotlinWorkspaceService(
     }
 
     override fun didChangeConfiguration(params: DidChangeConfigurationParams) {
-        val settings = params.settings as JsonObject
-        config.debounceTime = settings.get("kotlin").asJsonObject.get("debounceTime").asLong
+        val settings = params.settings as? JsonObject
+        settings?.get("kotlin")?.asJsonObject?.apply {
+            get("debounceTime")?.asLong?.let { config.debounceTime = it }
+            get("snippetsEnabled")?.asBoolean?.let { config.snippetsEnabled = it }
+        }
+        
         docService.updateDebouncer()
         LOG.info("configurations updated {}", settings)
     }

--- a/server/src/main/kotlin/org/javacs/kt/completion/RenderCompletionItem.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/RenderCompletionItem.kt
@@ -29,6 +29,9 @@ private val GOOD_IDENTIFIER = Regex("[a-zA-Z]\\w*")
 
 class RenderCompletionItem(val snippetsEnabled: Boolean) : DeclarationDescriptorVisitor<CompletionItem, Unit> {
     private val result = CompletionItem()
+    
+    private val functionInsertFormat
+        get() = if (snippetsEnabled) Snippet else PlainText
 
     private fun escape(id: String): String =
         if (id.matches(GOOD_IDENTIFIER)) id
@@ -55,7 +58,7 @@ class RenderCompletionItem(val snippetsEnabled: Boolean) : DeclarationDescriptor
 
         result.kind = Constructor
         result.insertText = functionInsertText(desc)
-        result.insertTextFormat = Snippet
+        result.insertTextFormat = functionInsertFormat
 
         return result
     }
@@ -81,7 +84,7 @@ class RenderCompletionItem(val snippetsEnabled: Boolean) : DeclarationDescriptor
 
         result.kind = Function
         result.insertText = functionInsertText(desc)
-        result.insertTextFormat = Snippet
+        result.insertTextFormat = functionInsertFormat
 
         return result
     }
@@ -89,10 +92,11 @@ class RenderCompletionItem(val snippetsEnabled: Boolean) : DeclarationDescriptor
     private fun functionInsertText(desc: FunctionDescriptor): String {
         val name = escape(desc.label()!!)
 
-        return if (desc.valueParameters.isEmpty())
-            "$name()"
-        else
-            "$name(${desc.valueParameters.mapIndexed { index, vpd -> "\${${index + 1}:${vpd.name}}" }.joinToString()})"
+        return when {
+            !snippetsEnabled -> name
+            desc.valueParameters.isEmpty() -> "$name()"
+            else -> "$name(${desc.valueParameters.mapIndexed { index, vpd -> "\${${index + 1}:${vpd.name}}" }.joinToString()})"
+        }
     }
 
     override fun visitModuleDeclaration(desc: ModuleDescriptor, nothing: Unit?): CompletionItem {

--- a/server/src/main/kotlin/org/javacs/kt/completion/RenderCompletionItem.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/RenderCompletionItem.kt
@@ -27,7 +27,7 @@ val DECL_RENDERER = DescriptorRenderer.withOptions {
 
 private val GOOD_IDENTIFIER = Regex("[a-zA-Z]\\w*")
 
-class RenderCompletionItem : DeclarationDescriptorVisitor<CompletionItem, Unit> {
+class RenderCompletionItem(val snippetsEnabled: Boolean) : DeclarationDescriptorVisitor<CompletionItem, Unit> {
     private val result = CompletionItem()
 
     private fun escape(id: String): String =

--- a/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
+++ b/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
@@ -19,7 +19,17 @@ abstract class LanguageServerTestFixture(relativeWorkspaceRoot: String) : Langua
 
     private fun createLanguageServer(): KotlinLanguageServer {
         val languageServer = KotlinLanguageServer()
-        val init = InitializeParams()
+        val init = InitializeParams().apply {
+            capabilities = ClientCapabilities().apply {
+                textDocument = TextDocumentClientCapabilities().apply {
+                    completion = CompletionCapabilities().apply {
+                        completionItem = CompletionItemCapabilities().apply {
+                            snippetSupport = true
+                        }
+                    }
+                }
+            }
+        }
 
         init.rootUri = workspaceRoot.toUri().toString()
         languageServer.initialize(init)


### PR DESCRIPTION
Provide non-snippet completions if the client does not set the `snippetSupport` flag. Fixes #119.