### PR TITLE
Fix an issue when exception in KotlinTextDocumentService#doLint

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -213,13 +213,16 @@ class KotlinTextDocumentService(
     }
 
     private fun doLint() {
-        LOG.info("Linting {}", describeFiles(lintTodo))
         linting = true
-        val files = clearLint()
-        val context = sp.compileFiles(files)
-        reportDiagnostics(files, context.diagnostics)
-        lintCount++
-        linting = false
+        try {
+            LOG.info("Linting {}", describeFiles(lintTodo))
+            val files = clearLint()
+            val context = sp.compileFiles(files)
+            reportDiagnostics(files, context.diagnostics)
+            lintCount++
+        } finally {
+            linting = false
+        }
     }
 
     private fun reportDiagnostics(compiled: Collection<Path>, kotlinDiagnostics: Diagnostics) {


### PR DESCRIPTION
[KotlinTextDocumentService#linting](https://github.com/fwcd/KotlinLanguageServer/blob/master/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt#L33) is set to `true` at the [first](https://github.com/fwcd/KotlinLanguageServer/blob/4e28547ffb32edf0ca39db01cef6ef0aeb1c1949/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt#L217) of [KotlinTextDocumentService#doLint](https://github.com/fwcd/KotlinLanguageServer/blob/master/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt#L215) and then set to `false` at [end](https://github.com/fwcd/KotlinLanguageServer/blob/4e28547ffb32edf0ca39db01cef6ef0aeb1c1949/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt#L222) of there.  
But if an exception (e.g. #42) is occurred, it is never set to `false`.  
As a result, [KotlinTextDocumentService#lintLater](https://github.com/fwcd/KotlinLanguageServer/blob/4e28547ffb32edf0ca39db01cef6ef0aeb1c1949/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt#L204) will not call [KotlinTextDocumentService#doLint](https://github.com/fwcd/KotlinLanguageServer/blob/master/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt#L215) after that.