### PR TITLE
Better build instructions w.r.t Java version

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,7 +2,7 @@
 Describes how to build and run this project. Note that you might need to use `gradlew` instead of `./gradlew` on Windows.
 
 ## Setup
-* Java 8+ should be installed and located under JAVA_HOME or PATH
+* Java 8 should be installed and located under JAVA_HOME or PATH. Java 11 is *not* supported yet, see [#108](https://github.com/fwcd/KotlinLanguageServer/issues/108) for details.
 
 ### ...for language server development
 * `./gradlew server:build`


### PR DESCRIPTION
The current build doc is confusing, in that it says "Java 8+ should be installed". 

Most developers (myself included) will take this to mean that _any_ version 8+ will work, yet Java 11 fails with known issues. This PR corrects the language to make it clear that the user needs Java 8, and no other later version actually works yet.