### PR TITLE
Add JVM Target configuration option

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
                     "default": true,
                     "description": "Specifies whether the language server should be used. When enabled the extension will provide code completions and linting, otherwise just syntax highlighting. Might require a reload to apply."
                 },
+                "kotlin.compiler.jvm.target": {
+                    "type": "string",
+                    "default": "default",
+                    "description": "Specifies the JVM target, e.g. \"1.6\" or \"1.8\""
+                },
                 "kotlin.linting.debounceTime": {
                     "type": "integer",
                     "default": 250,

--- a/package.json
+++ b/package.json
@@ -63,15 +63,27 @@
                     "default": true,
                     "description": "Specifies whether the language server should be used. When enabled the extension will provide code completions and linting, otherwise just syntax highlighting. Might require a reload to apply."
                 },
-                "kotlin.debounceTime": {
+                "kotlin.linting.debounceTime": {
                     "type": "integer",
                     "default": 250,
                     "description": "[DEBUG] Specifies the debounce time limit. Lower to increase responsiveness at the cost of possibile stability issues"
                 },
-                "kotlin.snippetsEnabled": {
+                "kotlin.completion.snippets.enabled": {
                     "type": "boolean",
                     "default": true,
                     "description": "Specifies whether code completion should provide snippets (true) or plain-text items (false)"
+                },
+                "kotlin.debounceTime": {
+                    "type": "integer",
+                    "default": 250,
+                    "description": "[DEPRECATED] Specifies the debounce time limit. Lower to increase responsiveness at the cost of possibile stability issues",
+                    "deprecationMessage": "Use 'kotlin.linting.debounceTime' instead"
+                },
+                "kotlin.snippetsEnabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "[DEPRECATED] Specifies whether code completion should provide snippets (true) or plain-text items (false)",
+                    "deprecationMessage": "Use 'kotlin.completion.snippets.enabled'"
                 }
             }
         }

--- a/server/src/main/kotlin/org/javacs/kt/Compiler.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Compiler.kt
@@ -94,7 +94,7 @@ class Compiler(classPath: Set<Path>) {
 
     private fun jvmTargetFrom(target: String): JvmTarget? = when (target) {
         // See https://github.com/JetBrains/kotlin/blob/master/compiler/frontend.java/src/org/jetbrains/kotlin/config/JvmTarget.kt
-        "default" -> null
+        "default" -> JvmTarget.DEFAULT
         "1.6" -> JvmTarget.JVM_1_6
         "1.8" -> JvmTarget.JVM_1_8
         // TODO: Add once Java 9+ is supported

--- a/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
@@ -3,11 +3,15 @@ package org.javacs.kt
 import org.javacs.kt.classpath.findClassPath
 import java.nio.file.Path
 
-class CompilerClassPath {
+class CompilerClassPath(private val config: CompilerConfiguration) {
     private val workspaceRoots = mutableSetOf<Path>()
     private val classPath = mutableSetOf<Path>()
     var compiler = Compiler(classPath)
         private set
+
+    init {
+        compiler.updateConfiguration(config)
+    }
 
     private fun refresh() {
         val newClassPath = findClassPath(workspaceRoots)
@@ -22,7 +26,12 @@ class CompilerClassPath {
             classPath.removeAll(removed)
             classPath.addAll(added)
             compiler = Compiler(classPath)
+            updateCompilerConfiguration()
         }
+    }
+
+    fun updateCompilerConfiguration() {
+        compiler.updateConfiguration(config)
     }
 
     fun addWorkspaceRoot(root: Path) {

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -1,6 +1,18 @@
 package org.javacs.kt
 
-public class Configuration(
-    var debounceTime: Long = 250L,
-    var snippetsEnabled: Boolean = true
+public data class SnippetsConfiguration(
+    var enabled: Boolean = true
+)
+
+public data class CompletionConfiguration(
+    val snippets: SnippetsConfiguration = SnippetsConfiguration()
+)
+
+public data class LintingConfiguration(
+    var debounceTime: Long = 250L
+)
+
+public data class Configuration(
+    val completion: CompletionConfiguration = CompletionConfiguration(),
+    val linting: LintingConfiguration = LintingConfiguration()
 )

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -12,7 +12,16 @@ public data class LintingConfiguration(
     var debounceTime: Long = 250L
 )
 
+public data class JVMConfiguration(
+    var target: String = "default" // See Compiler.jvmTargetFrom for possible values
+)
+
+public data class CompilerConfiguration(
+    val jvm: JVMConfiguration = JVMConfiguration()
+)
+
 public data class Configuration(
+    val compiler: CompilerConfiguration = CompilerConfiguration(),
     val completion: CompletionConfiguration = CompletionConfiguration(),
     val linting: LintingConfiguration = LintingConfiguration()
 )

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -57,7 +57,7 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware {
         serverCapabilities.executeCommandProvider = ExecuteCommandOptions(ALL_COMMANDS)
 
         val clientCapabilities = params.capabilities
-        config.snippetsEnabled = clientCapabilities?.textDocument?.completion?.completionItem?.snippetSupport ?: false
+        config.completion.snippets.enabled = clientCapabilities?.textDocument?.completion?.completionItem?.snippetSupport ?: false
 
         if (params.rootUri != null) {
             LOG.info("Adding workspace {} to source path", params.rootUri)

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -12,10 +12,10 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletableFuture.completedFuture
 
 class KotlinLanguageServer : LanguageServer, LanguageClientAware {
-    val classPath = CompilerClassPath()
+    private val config = Configuration()
+    val classPath = CompilerClassPath(config.compiler)
     val sourcePath = SourcePath(classPath)
     val sourceFiles = SourceFiles(sourcePath)
-    private val config = Configuration()
     private val textDocuments = KotlinTextDocumentService(sourceFiles, sourcePath, config)
     private val workspaces = KotlinWorkspaceService(sourceFiles, sourcePath, classPath, textDocuments, config)
 

--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -32,7 +32,7 @@ class KotlinTextDocumentService(
     private val async = AsyncExecutor()
     private var linting = false
 
-    var debounceLint = Debouncer(Duration.ofMillis(config.debounceTime))
+    var debounceLint = Debouncer(Duration.ofMillis(config.linting.debounceTime))
     val lintTodo = mutableSetOf<Path>()
     var lintCount = 0
 
@@ -115,7 +115,7 @@ class KotlinTextDocumentService(
             LOG.info("Completing at {}", describePosition(position))
 
             val (file, cursor) = recover(position, false)
-            val completions = completions(file, cursor, config.snippetsEnabled)
+            val completions = completions(file, cursor, config.completion)
 
             LOG.info("Found {} items", completions.items.size)
 
@@ -190,7 +190,7 @@ class KotlinTextDocumentService(
     }
 
     public fun updateDebouncer() {
-        debounceLint = Debouncer(Duration.ofMillis(config.debounceTime))
+        debounceLint = Debouncer(Duration.ofMillis(config.linting.debounceTime))
     }
 
     private fun clearLint(): List<Path> {

--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -81,10 +81,24 @@ class KotlinWorkspaceService(
     override fun didChangeConfiguration(params: DidChangeConfigurationParams) {
         val settings = params.settings as? JsonObject
         settings?.get("kotlin")?.asJsonObject?.apply {
-            get("debounceTime")?.asLong?.let { config.debounceTime = it }
-            get("snippetsEnabled")?.asBoolean?.let { config.snippetsEnabled = it }
+            // Support deprecated configuration keys
+            get("debounceTime")?.asLong?.let { config.linting.debounceTime = it }
+            get("snippetsEnabled")?.asBoolean?.let { config.completion.snippets.enabled = it }
+
+            get("linting")?.asJsonObject?.apply {
+                val linting = config.linting
+                get("debounceTime")?.asLong?.let { linting.debounceTime = it }
+            }
+
+            get("completion")?.asJsonObject?.apply {
+                val completion = config.completion
+                get("snippets")?.asJsonObject?.apply {
+                    val snippets = completion.snippets
+                    get("enabled")?.asBoolean?.let { snippets.enabled = it }
+                }
+            }
         }
-        
+
         docService.updateDebouncer()
         LOG.info("configurations updated {}", settings)
     }

--- a/server/src/test/kotlin/org/javacs/kt/CompiledFileTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/CompiledFileTest.kt
@@ -13,7 +13,7 @@ class CompiledFileTest {
         val file = testResourcesRoot().resolve("compiledFile/CompiledFileExample.kt")
         val content = Files.readAllLines(file).joinToString("\n")
         val parse = compiler.createFile(content, file)
-        val classPath = CompilerClassPath()
+        val classPath = CompilerClassPath(CompilerConfiguration())
         val sourcePath = listOf(parse)
         val (context, container) = compiler.compileFiles(sourcePath, sourcePath)
         return CompiledFile(content, parse, context, container, sourcePath, classPath)

--- a/server/src/test/kotlin/org/javacs/kt/SimpleScriptTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/SimpleScriptTest.kt
@@ -2,7 +2,8 @@ package org.javacs.kt
 
 import org.jetbrains.kotlin.cli.common.repl.*
 import org.jetbrains.kotlin.cli.jvm.repl.*
-import org.jetbrains.kotlin.config.*
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.CompilerConfiguration as KotlinCompilerConfiguration
 import org.jetbrains.kotlin.script.*
 import com.intellij.openapi.util.*
 import org.jetbrains.kotlin.cli.common.messages.*
@@ -19,7 +20,7 @@ class SimpleScriptTest {
     fun basicScript() {
         val scriptDef = KotlinScriptDefinition(Any::class)
         val repl = GenericReplEvaluator(listOf())
-        val config = CompilerConfiguration()
+        val config = KotlinCompilerConfiguration()
         config.put(CommonConfigurationKeys.MODULE_NAME, JvmAbi.DEFAULT_MODULE_NAME)
         val compiler = GenericReplCompiler(scriptDef, config, MessageCollector.NONE)
         val compilerState = compiler.createState()
@@ -38,7 +39,7 @@ class SimpleScriptTest {
             is ReplEvalResult.UnitResult -> println('_')
         }
     }
-    
+
     private fun assertNotError(result: ReplCompileResult) {
         if (result is ReplCompileResult.Error) {
             fail(result.message)

--- a/vscode-extension-src/extension.ts
+++ b/vscode-extension-src/extension.ts
@@ -27,10 +27,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 export function deactivate(): void {}
 
 async function activateLanguageServer(context: vscode.ExtensionContext) {
-    LOG.info('Activating Kotlin language server...');
+    LOG.info('Activating Kotlin Language Server...');
     let barItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
     context.subscriptions.push(barItem);
-    barItem.text = '$(sync) Activating Kotlin language server...';
+    barItem.text = '$(sync~spin) Activating Kotlin Language Server...';
     barItem.show();
 
     let javaExecutablePath = findJavaExecutable('java');


### PR DESCRIPTION
Add a configuration option `kotlin.compiler.jvm.target` that lets the user specify the JVM version. Currently only `1.6` and `1.8` are supported (though `9`, `10`, `11`, `12` will be too once #109 is merged).

Additionally clean up the configuration structure by making it more hierarchial. The old structure

```
kotlin
+ languageServer
|   + enabled
+ debounceTime
+ snippetsEnabled
```

has been migrated to

```
kotlin
+ languageServer
|   + enabled
+ compiler
|   + jvm
|       + target
+ linting
|   + debounceTime
+ completion
    + snippets
        + enabled
```

Fixes #72.