### PR TITLE
Rewrite Java-to-Kotlin-converter from scratch

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,14 +2,12 @@
 Describes how to build and run the language server and the editor extensions.
 
 ## Setup
-
-* Java 8 should be installed and located under JAVA_HOME or PATH. Java 11 is *not* supported yet, see [#108](https://github.com/fwcd/KotlinLanguageServer/issues/108) for details.
+* Java 8+ should be installed and located under `JAVA_HOME` or `PATH`.
 * Note that you might need to use `gradlew` instead of `./gradlew` for the commands on Windows.
 
 ## Language Server
 
 ### Building
-
 If you just want to build the language server and use its binaries in your client of choice, run:
 
 >`./gradlew :server:installDist`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A [language server](https://microsoft.github.io/language-server-protocol/) that 
 Any editor conforming to LSP is supported, including [VSCode](https://code.visualstudio.com) and [Atom](https://atom.io) for which client extensions provided by this repository.
 
 ## Getting Started
-* See [BUILDING.md](BUILDING.md) for build instructions.
+* See [BUILDING.md](BUILDING.md) for build instructions
+* See [Editor Integration](editors/README.md) for editor-specific instructions
 * See [Roadmap](https://github.com/fwcd/KotlinLanguageServer/projects/1) for features, planned additions, bugfixes and changes
 * See [KotlinQuickStart](https://github.com/fwcd/KotlinQuickStart) for a sample project
 * See [KotlinDebugAdapter](https://github.com/fwcd/KotlinDebugAdapter) for debugging support on JVM

--- a/editors/README.md
+++ b/editors/README.md
@@ -23,4 +23,4 @@ let g:LanguageClient_serverCommands = {
 ```
 
 ## Other Editors
-Invoke the language server executable in a client-specific way. The server uses `stdio` to send and receive `JSON-RPC` messages.
+Install a [Language Server Protocol client](https://microsoft.github.io/language-server-protocol/implementors/tools/) for your tool. Then invoke the language server executable in a client-specific way. The server uses `stdio` to send and receive `JSON-RPC` messages.

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -46,14 +46,14 @@ private const val MAX_COMPLETION_ITEMS = 50
 fun completions(file: CompiledFile, cursor: Int, config: CompletionConfiguration): CompletionList {
     val partial = findPartialIdentifier(file, cursor)
     LOG.debug("Looking for completions that match '{}'", partial)
-    
+
     val items = elementCompletionItems(file, cursor, config, partial).ifEmpty { keywordCompletionItems(partial) }
     val itemList = items
         .take(MAX_COMPLETION_ITEMS)
         .toList()
         .onEachIndexed { i, item -> item.sortText = i.toString().padStart(2, '0') }
     val isIncomplete = (itemList.size == MAX_COMPLETION_ITEMS)
-    
+
     return CompletionList(isIncomplete, itemList)
 }
 
@@ -71,11 +71,11 @@ private fun keywordCompletionItems(partial: String): Sequence<CompletionItem> =
 private fun elementCompletionItems(file: CompiledFile, cursor: Int, config: CompletionConfiguration, partial: String): Sequence<CompletionItem> {
     val surroundingElement = completableElement(file, cursor) ?: return emptySequence()
     val completions = elementCompletions(file, cursor, surroundingElement)
-    
+
     val nameFilter = matchesPartialIdentifier(partial)
     val matchesName = completions.filter(nameFilter)
     val visible = matchesName.filter(isVisible(file, cursor))
-    
+
     return visible.map { completionItem(it, surroundingElement, file, config) }
 }
 
@@ -112,7 +112,7 @@ private fun isJavaCodeAndInstanceMethod(
     descriptor: DeclarationDescriptor
 ): Boolean {
     val javaMethodDescriptor = descriptor as? JavaMethodDescriptor ?: return false
-    val source = javaMethodDescriptor.source as? JavaSourceElement ?: return false
+    val source = javaMethodDescriptor.source as? JavaSourceElement ?: return true
     val javaElement = source.javaElement
     return javaElement is JavaMethod && !javaElement.isStatic
 }

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt
@@ -1,5 +1,6 @@
 package org.javacs.kt.j2k
 
+import org.javacs.kt.LOG
 import org.jetbrains.kotlin.com.intellij.psi.*
 import org.jetbrains.kotlin.com.intellij.psi.javadoc.*
 
@@ -14,7 +15,6 @@ class JavaElementConverter(
     var translatedKotlinCode: String? = null
         private set
     private val indent: String = "".padStart(indentLevel * indentSize, ' ')
-    private val nextIndent: String = "".padStart((indentLevel + 1) * indentSize, ' ')
 
     private val String?.spacePrefixed: String
         get() = this?.let { " $it" } ?: ""
@@ -24,59 +24,98 @@ class JavaElementConverter(
         .also { this?.accept(it) }
         .translatedKotlinCode
 
+    private fun nextIndent(indentDelta: Int = 1): String = ""
+        .padStart((indentLevel + indentDelta) * indentSize, ' ')
+
+    private fun List<String>.buildCodeBlock(indentDelta: Int = 1): String {
+        val indentedStatements = this
+            .map { "${nextIndent(indentDelta)}$it" }
+            .joinToString(separator = "\n")
+        return "{$indentedStatements\n$indent}"
+    }
+
+    private fun PsiType.translate(): String = accept(JavaTypeConverter)
+
     override fun visitAnonymousClass(aClass: PsiAnonymousClass) {
         super.visitAnonymousClass(aClass)
+        LOG.warn("J2K can not convert AnonymousClass yet")
     }
 
     override fun visitArrayAccessExpression(expression: PsiArrayAccessExpression) {
         super.visitArrayAccessExpression(expression)
+        LOG.warn("J2K can not convert ArrayAccessExpression yet")
     }
 
     override fun visitArrayInitializerExpression(expression: PsiArrayInitializerExpression) {
         super.visitArrayInitializerExpression(expression)
+        LOG.warn("J2K can not convert ArrayInitializerExpression yet")
     }
 
     override fun visitAssertStatement(statement: PsiAssertStatement) {
         super.visitAssertStatement(statement)
+        LOG.warn("J2K can not convert AssertStatement yet")
     }
 
     override fun visitAssignmentExpression(expression: PsiAssignmentExpression) {
         super.visitAssignmentExpression(expression)
+        LOG.warn("J2K can not convert AssignmentExpression yet")
     }
 
     override fun visitBinaryExpression(expression: PsiBinaryExpression) {
         super.visitBinaryExpression(expression)
+        LOG.warn("J2K can not convert BinaryExpression yet")
     }
 
     override fun visitBlockStatement(statement: PsiBlockStatement) {
         super.visitBlockStatement(statement)
+        LOG.warn("J2K can not convert BlockStatement yet")
     }
 
     override fun visitBreakStatement(statement: PsiBreakStatement) {
         super.visitBreakStatement(statement)
+        LOG.warn("J2K can not convert BreakStatement yet")
     }
 
     override fun visitClass(aClass: PsiClass) {
-        translatedKotlinCode = aClass.qualifiedName
+        val (staticMembers, instanceMembers) = aClass.children
+            .mapNotNull { it as? PsiMember }
+            .partition { it.hasModifierProperty(PsiModifier.STATIC) }
+
+        val translatedInstanceMembers = instanceMembers
+            .mapNotNull { it.translate(indentDelta = 1) }
+
+        val translatedCompanion = if (!staticMembers.isEmpty()) {
+            val translatedCompanionBlock = staticMembers
+                .map { "@JvmStatic ${it.translate(indentDelta = 2)}" }
+                .buildCodeBlock()
+                .spacePrefixed
+            "companion object$translatedCompanionBlock"
+        } else ""
+
+        val translatedBody = (listOf(translatedCompanion) + translatedInstanceMembers)
+            .buildCodeBlock()
+            .spacePrefixed
+
+        translatedKotlinCode = "class ${aClass.qualifiedName}$translatedBody"
     }
 
     override fun visitClassInitializer(initializer: PsiClassInitializer) {
-        translatedKotlinCode = "class ${initializer.containingClass?.qualifiedName}${initializer.body.translate().spacePrefixed}"
+        translatedKotlinCode = "init${initializer.body.translate().spacePrefixed}"
     }
 
     override fun visitClassObjectAccessExpression(expression: PsiClassObjectAccessExpression) {
         super.visitClassObjectAccessExpression(expression)
+        LOG.warn("J2K can not convert ClassObjectAccessExpression yet")
     }
 
     override fun visitCodeBlock(block: PsiCodeBlock) {
-        val indentedStatements = block.statements
-            .map { "$nextIndent${it.translate(indentDelta = 1)}" }
-            .joinToString(separator = "\n")
-        translatedKotlinCode = "{$indentedStatements\n$indent}"
+        val translated = block.statements.mapNotNull { it.translate(indentDelta = 1) }
+        translatedKotlinCode = translated.buildCodeBlock()
     }
 
     override fun visitConditionalExpression(expression: PsiConditionalExpression) {
         super.visitConditionalExpression(expression)
+        LOG.warn("J2K can not convert ConditionalExpression yet")
     }
 
     override fun visitContinueStatement(statement: PsiContinueStatement) {
@@ -85,22 +124,27 @@ class JavaElementConverter(
 
     override fun visitDeclarationStatement(statement: PsiDeclarationStatement) {
         super.visitDeclarationStatement(statement)
+        LOG.warn("J2K can not convert DeclarationStatement yet")
     }
 
     override fun visitDocComment(comment: PsiDocComment) {
         super.visitDocComment(comment)
+        LOG.warn("J2K can not convert DocComment yet")
     }
 
     override fun visitDocTag(tag: PsiDocTag) {
         super.visitDocTag(tag)
+        LOG.warn("J2K can not convert DocTag yet")
     }
 
     override fun visitDocTagValue(value: PsiDocTagValue) {
         super.visitDocTagValue(value)
+        LOG.warn("J2K can not convert DocTagValue yet")
     }
 
     override fun visitDoWhileStatement(statement: PsiDoWhileStatement) {
         super.visitDoWhileStatement(statement)
+        LOG.warn("J2K can not convert DoWhileStatement yet")
     }
 
     override fun visitEmptyStatement(statement: PsiEmptyStatement) {
@@ -113,26 +157,32 @@ class JavaElementConverter(
 
     override fun visitExpressionList(list: PsiExpressionList) {
         super.visitExpressionList(list)
+        LOG.warn("J2K can not convert ExpressionList yet")
     }
 
     override fun visitExpressionListStatement(statement: PsiExpressionListStatement) {
         super.visitExpressionListStatement(statement)
+        LOG.warn("J2K can not convert ExpressionListStatement yet")
     }
 
     override fun visitExpressionStatement(statement: PsiExpressionStatement) {
         super.visitExpressionStatement(statement)
+        LOG.warn("J2K can not convert ExpressionStatement yet")
     }
 
     override fun visitField(field: PsiField) {
         super.visitField(field)
+        LOG.warn("J2K can not convert Field yet")
     }
 
     override fun visitForStatement(statement: PsiForStatement) {
         super.visitForStatement(statement)
+        LOG.warn("J2K can not convert ForStatement yet")
     }
 
     override fun visitForeachStatement(statement: PsiForeachStatement) {
         super.visitForeachStatement(statement)
+        LOG.warn("J2K can not convert ForeachStatement yet")
     }
 
     override fun visitIdentifier(identifier: PsiIdentifier) {
@@ -147,288 +197,358 @@ class JavaElementConverter(
 
     override fun visitImportList(list: PsiImportList) {
         super.visitImportList(list)
+        LOG.warn("J2K can not convert ImportList yet")
     }
 
     override fun visitImportStatement(statement: PsiImportStatement) {
         super.visitImportStatement(statement)
+        LOG.warn("J2K can not convert ImportStatement yet")
     }
 
     override fun visitImportStaticStatement(statement: PsiImportStaticStatement) {
         super.visitImportStaticStatement(statement)
+        LOG.warn("J2K can not convert ImportStaticStatement yet")
     }
 
     override fun visitInlineDocTag(tag: PsiInlineDocTag) {
         super.visitInlineDocTag(tag)
+        LOG.warn("J2K can not convert InlineDocTag yet")
     }
 
     override fun visitInstanceOfExpression(expression: PsiInstanceOfExpression) {
         super.visitInstanceOfExpression(expression)
+        LOG.warn("J2K can not convert InstanceOfExpression yet")
     }
 
     override fun visitJavaToken(token: PsiJavaToken) {
         super.visitJavaToken(token)
+        LOG.warn("J2K can not convert JavaToken yet")
     }
 
     override fun visitKeyword(keyword: PsiKeyword) {
         super.visitKeyword(keyword)
+        LOG.warn("J2K can not convert Keyword yet")
     }
 
     override fun visitLabeledStatement(statement: PsiLabeledStatement) {
         super.visitLabeledStatement(statement)
+        LOG.warn("J2K can not convert LabeledStatement yet")
     }
 
     override fun visitLiteralExpression(expression: PsiLiteralExpression) {
         super.visitLiteralExpression(expression)
+        LOG.warn("J2K can not convert LiteralExpression yet")
     }
 
     override fun visitLocalVariable(variable: PsiLocalVariable) {
         super.visitLocalVariable(variable)
+        LOG.warn("J2K can not convert LocalVariable yet")
     }
 
     override fun visitMethod(method: PsiMethod) {
-        super.visitMethod(method)
+        // TODO: Type parameters, annotations, modifiers, ...
+        val translatedBody = method.body.translate().spacePrefixed
+        translatedKotlinCode = "fun ${method.name}(${method.parameterList.translate()})$translatedBody"
     }
 
     override fun visitMethodCallExpression(expression: PsiMethodCallExpression) {
         super.visitMethodCallExpression(expression)
+        LOG.warn("J2K can not convert MethodCallExpression yet")
     }
 
     override fun visitCallExpression(callExpression: PsiCallExpression) {
         super.visitCallExpression(callExpression)
+        LOG.warn("J2K can not convert CallExpression yet")
     }
 
     override fun visitModifierList(list: PsiModifierList) {
         super.visitModifierList(list)
+        LOG.warn("J2K can not convert ModifierList yet")
     }
 
     override fun visitNewExpression(expression: PsiNewExpression) {
         super.visitNewExpression(expression)
+        LOG.warn("J2K can not convert NewExpression yet")
     }
 
     override fun visitPackage(aPackage: PsiPackage) {
         super.visitPackage(aPackage)
+        LOG.warn("J2K can not convert Package yet")
     }
 
     override fun visitPackageStatement(statement: PsiPackageStatement) {
         super.visitPackageStatement(statement)
+        LOG.warn("J2K can not convert PackageStatement yet")
     }
 
     override fun visitParameter(parameter: PsiParameter) {
-        super.visitParameter(parameter)
+        // TODO: Varargs, ...
+        translatedKotlinCode = "${parameter.name}: ${parameter.type.translate()}"
     }
 
     override fun visitReceiverParameter(parameter: PsiReceiverParameter) {
         super.visitReceiverParameter(parameter)
+        LOG.warn("J2K can not convert ReceiverParameter yet")
     }
 
     override fun visitParameterList(list: PsiParameterList) {
-        super.visitParameterList(list)
+        translatedKotlinCode = list.parameters
+            .mapNotNull { it.translate() }
+            .joinToString(separator = ", ")
     }
 
     override fun visitParenthesizedExpression(expression: PsiParenthesizedExpression) {
         super.visitParenthesizedExpression(expression)
+        LOG.warn("J2K can not convert ParenthesizedExpression yet")
     }
 
     override fun visitUnaryExpression(expression: PsiUnaryExpression) {
         super.visitUnaryExpression(expression)
+        LOG.warn("J2K can not convert UnaryExpression yet")
     }
 
     override fun visitPostfixExpression(expression: PsiPostfixExpression) {
         super.visitPostfixExpression(expression)
+        LOG.warn("J2K can not convert PostfixExpression yet")
     }
 
     override fun visitPrefixExpression(expression: PsiPrefixExpression) {
         super.visitPrefixExpression(expression)
+        LOG.warn("J2K can not convert PrefixExpression yet")
     }
 
     override fun visitReferenceElement(reference: PsiJavaCodeReferenceElement) {
         super.visitReferenceElement(reference)
+        LOG.warn("J2K can not convert ReferenceElement yet")
     }
 
     override fun visitImportStaticReferenceElement(reference: PsiImportStaticReferenceElement) {
         super.visitImportStaticReferenceElement(reference)
+        LOG.warn("J2K can not convert ImportStaticReferenceElement yet")
     }
 
     override fun visitReferenceExpression(expression: PsiReferenceExpression) {}
 
     override fun visitMethodReferenceExpression(expression: PsiMethodReferenceExpression) {
         super.visitMethodReferenceExpression(expression)
+        LOG.warn("J2K can not convert MethodReferenceExpression yet")
     }
 
     override fun visitReferenceList(list: PsiReferenceList) {
         super.visitReferenceList(list)
+        LOG.warn("J2K can not convert ReferenceList yet")
     }
 
     override fun visitReferenceParameterList(list: PsiReferenceParameterList) {
         super.visitReferenceParameterList(list)
+        LOG.warn("J2K can not convert ReferenceParameterList yet")
     }
 
     override fun visitTypeParameterList(list: PsiTypeParameterList) {
         super.visitTypeParameterList(list)
+        LOG.warn("J2K can not convert TypeParameterList yet")
     }
 
     override fun visitReturnStatement(statement: PsiReturnStatement) {
         super.visitReturnStatement(statement)
+        LOG.warn("J2K can not convert ReturnStatement yet")
     }
 
     override fun visitStatement(statement: PsiStatement) {
         super.visitStatement(statement)
+        LOG.warn("J2K can not convert Statement yet")
     }
 
     override fun visitSuperExpression(expression: PsiSuperExpression) {
         super.visitSuperExpression(expression)
+        LOG.warn("J2K can not convert SuperExpression yet")
     }
 
     override fun visitSwitchLabelStatement(statement: PsiSwitchLabelStatement) {
         super.visitSwitchLabelStatement(statement)
+        LOG.warn("J2K can not convert SwitchLabelStatement yet")
     }
 
     override fun visitSwitchLabeledRuleStatement(statement: PsiSwitchLabeledRuleStatement) {
         super.visitSwitchLabeledRuleStatement(statement)
+        LOG.warn("J2K can not convert SwitchLabeledRuleStatement yet")
     }
 
     override fun visitSwitchStatement(statement: PsiSwitchStatement) {
         super.visitSwitchStatement(statement)
+        LOG.warn("J2K can not convert SwitchStatement yet")
     }
 
     override fun visitSynchronizedStatement(statement: PsiSynchronizedStatement) {
         super.visitSynchronizedStatement(statement)
+        LOG.warn("J2K can not convert SynchronizedStatement yet")
     }
 
     override fun visitThisExpression(expression: PsiThisExpression) {
         super.visitThisExpression(expression)
+        LOG.warn("J2K can not convert ThisExpression yet")
     }
 
     override fun visitThrowStatement(statement: PsiThrowStatement) {
         super.visitThrowStatement(statement)
+        LOG.warn("J2K can not convert ThrowStatement yet")
     }
 
     override fun visitTryStatement(statement: PsiTryStatement) {
         super.visitTryStatement(statement)
+        LOG.warn("J2K can not convert TryStatement yet")
     }
 
     override fun visitCatchSection(section: PsiCatchSection) {
         super.visitCatchSection(section)
+        LOG.warn("J2K can not convert CatchSection yet")
     }
 
     override fun visitResourceList(resourceList: PsiResourceList) {
         super.visitResourceList(resourceList)
+        LOG.warn("J2K can not convert ResourceList yet")
     }
 
     override fun visitResourceVariable(variable: PsiResourceVariable) {
         super.visitResourceVariable(variable)
+        LOG.warn("J2K can not convert ResourceVariable yet")
     }
 
     override fun visitResourceExpression(expression: PsiResourceExpression) {
         super.visitResourceExpression(expression)
+        LOG.warn("J2K can not convert ResourceExpression yet")
     }
 
     override fun visitTypeElement(type: PsiTypeElement) {
         super.visitTypeElement(type)
+        LOG.warn("J2K can not convert TypeElement yet")
     }
 
     override fun visitTypeCastExpression(expression: PsiTypeCastExpression) {
         super.visitTypeCastExpression(expression)
+        LOG.warn("J2K can not convert TypeCastExpression yet")
     }
 
     override fun visitVariable(variable: PsiVariable) {
         super.visitVariable(variable)
+        LOG.warn("J2K can not convert Variable yet")
     }
 
     override fun visitWhileStatement(statement: PsiWhileStatement) {
         super.visitWhileStatement(statement)
+        LOG.warn("J2K can not convert WhileStatement yet")
     }
 
     override fun visitJavaFile(file: PsiJavaFile) {
         // TODO: Package declarations, imports, ....
-        translatedKotlinCode = file.classes.asSequence()
-            .flatMap { it.initializers.asSequence() }
-            .map { it.translate() }
+        translatedKotlinCode = file.children.asSequence()
+            .mapNotNull { it.translate() }
             .joinToString(separator = "\n")
     }
 
     override fun visitImplicitVariable(variable: ImplicitVariable) {
         super.visitImplicitVariable(variable)
+        LOG.warn("J2K can not convert ImplicitVariable yet")
     }
 
     override fun visitDocToken(token: PsiDocToken) {
         super.visitDocToken(token)
+        LOG.warn("J2K can not convert DocToken yet")
     }
 
     override fun visitTypeParameter(classParameter: PsiTypeParameter) {
         super.visitTypeParameter(classParameter)
+        LOG.warn("J2K can not convert TypeParameter yet")
     }
 
     override fun visitAnnotation(annotation: PsiAnnotation) {
         super.visitAnnotation(annotation)
+        LOG.warn("J2K can not convert Annotation yet")
     }
 
     override fun visitAnnotationParameterList(list: PsiAnnotationParameterList) {
         super.visitAnnotationParameterList(list)
+        LOG.warn("J2K can not convert AnnotationParameterList yet")
     }
 
     override fun visitAnnotationArrayInitializer(initializer: PsiArrayInitializerMemberValue) {
         super.visitAnnotationArrayInitializer(initializer)
+        LOG.warn("J2K can not convert AnnotationArrayInitializer yet")
     }
 
     override fun visitNameValuePair(pair: PsiNameValuePair) {
         super.visitNameValuePair(pair)
+        LOG.warn("J2K can not convert NameValuePair yet")
     }
 
     override fun visitAnnotationMethod(method: PsiAnnotationMethod) {
         super.visitAnnotationMethod(method)
+        LOG.warn("J2K can not convert AnnotationMethod yet")
     }
 
     override fun visitEnumConstant(enumConstant: PsiEnumConstant) {
         super.visitEnumConstant(enumConstant)
+        LOG.warn("J2K can not convert EnumConstant yet")
     }
 
     override fun visitEnumConstantInitializer(enumConstantInitializer: PsiEnumConstantInitializer) {
         super.visitEnumConstantInitializer(enumConstantInitializer)
+        LOG.warn("J2K can not convert EnumConstantInitializer yet")
     }
 
     override fun visitCodeFragment(codeFragment: JavaCodeFragment) {
         super.visitCodeFragment(codeFragment)
+        LOG.warn("J2K can not convert CodeFragment yet")
     }
 
     override fun visitPolyadicExpression(expression: PsiPolyadicExpression) {
         super.visitPolyadicExpression(expression)
+        LOG.warn("J2K can not convert PolyadicExpression yet")
     }
 
     override fun visitLambdaExpression(expression: PsiLambdaExpression) {
         super.visitLambdaExpression(expression)
+        LOG.warn("J2K can not convert LambdaExpression yet")
     }
 
     override fun visitSwitchExpression(expression: PsiSwitchExpression) {
         super.visitSwitchExpression(expression)
+        LOG.warn("J2K can not convert SwitchExpression yet")
     }
 
     override fun visitModule(module: PsiJavaModule) {
         super.visitModule(module)
+        LOG.warn("J2K can not convert Module yet")
     }
 
     override fun visitModuleReferenceElement(refElement: PsiJavaModuleReferenceElement) {
         super.visitModuleReferenceElement(refElement)
+        LOG.warn("J2K can not convert ModuleReferenceElement yet")
     }
 
     override fun visitModuleStatement(statement: PsiStatement) {
         super.visitModuleStatement(statement)
+        LOG.warn("J2K can not convert ModuleStatement yet")
     }
 
     override fun visitRequiresStatement(statement: PsiRequiresStatement) {
         super.visitRequiresStatement(statement)
+        LOG.warn("J2K can not convert RequiresStatement yet")
     }
 
     override fun visitPackageAccessibilityStatement(statement: PsiPackageAccessibilityStatement) {
         super.visitPackageAccessibilityStatement(statement)
+        LOG.warn("J2K can not convert PackageAccessibilityStatement yet")
     }
 
     override fun visitUsesStatement(statement: PsiUsesStatement) {
         super.visitUsesStatement(statement)
+        LOG.warn("J2K can not convert UsesStatement yet")
     }
 
     override fun visitProvidesStatement(statement: PsiProvidesStatement) {
         super.visitProvidesStatement(statement)
+        LOG.warn("J2K can not convert ProvidesStatement yet")
     }
 }
 

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt
@@ -12,9 +12,18 @@ class JavaElementConverter(
     private val indentLevel: Int = 0,
     private val indentSize: Int = 4 // spaces
 ) : JavaElementVisitor() {
+    /**
+     * Contains the translated code. If code has multiple lines,
+     * the first line is *not* indented, all subsequent lines are
+     * indented by 'indentLevel' levels.
+     */
     var translatedKotlinCode: String? = null
         private set
     private val indent: String = "".padStart(indentLevel * indentSize, ' ')
+
+    // =================
+    // Extension methods
+    // =================
 
     private val String?.spacePrefixed: String
         get() = this?.let { " $it" } ?: ""
@@ -24,56 +33,75 @@ class JavaElementConverter(
         .also { this?.accept(it) }
         .translatedKotlinCode
 
+    /** Fetches the indented indent. */
     private fun nextIndent(indentDelta: Int = 1): String = ""
         .padStart((indentLevel + indentDelta) * indentSize, ' ')
 
+    /**
+     * Constructs a code block from a list of statements.
+     * Note that the 'indentDelta' refers to the layer
+     * of indentation *inside* the block.
+     */
     private fun List<String>.buildCodeBlock(indentDelta: Int = 1): String {
         val indentedStatements = this
             .map { "${nextIndent(indentDelta)}$it" }
             .joinToString(separator = "\n")
-        return "{$indentedStatements\n$indent}"
+        return "{\n$indentedStatements\n$indent}"
     }
 
+    /** Converts a PsiType to its Kotlin representation. */
     private fun PsiType.translate(): String = accept(JavaTypeConverter)
+
+    /** Converts a list of type arguments to its Kotlin representation. */
+    private fun PsiCallExpression.translateTypeArguments(): String = "<${typeArgumentList.translate()}>"
+
+    private fun j2kTODO(type: String) {
+        LOG.warn("J2K can not convert $type yet")
+        translatedKotlinCode = "/*$type*/"
+    }
+
+    // =================
+    // Visitor methods
+    // =================
 
     override fun visitAnonymousClass(aClass: PsiAnonymousClass) {
         super.visitAnonymousClass(aClass)
-        LOG.warn("J2K can not convert AnonymousClass yet")
+        j2kTODO("AnonymousClass")
     }
 
     override fun visitArrayAccessExpression(expression: PsiArrayAccessExpression) {
         super.visitArrayAccessExpression(expression)
-        LOG.warn("J2K can not convert ArrayAccessExpression yet")
+        j2kTODO("ArrayAccessExpression")
     }
 
     override fun visitArrayInitializerExpression(expression: PsiArrayInitializerExpression) {
         super.visitArrayInitializerExpression(expression)
-        LOG.warn("J2K can not convert ArrayInitializerExpression yet")
+        j2kTODO("ArrayInitializerExpression")
     }
 
     override fun visitAssertStatement(statement: PsiAssertStatement) {
         super.visitAssertStatement(statement)
-        LOG.warn("J2K can not convert AssertStatement yet")
+        j2kTODO("AssertStatement")
     }
 
     override fun visitAssignmentExpression(expression: PsiAssignmentExpression) {
         super.visitAssignmentExpression(expression)
-        LOG.warn("J2K can not convert AssignmentExpression yet")
+        j2kTODO("AssignmentExpression")
     }
 
     override fun visitBinaryExpression(expression: PsiBinaryExpression) {
         super.visitBinaryExpression(expression)
-        LOG.warn("J2K can not convert BinaryExpression yet")
+        j2kTODO("BinaryExpression")
     }
 
     override fun visitBlockStatement(statement: PsiBlockStatement) {
         super.visitBlockStatement(statement)
-        LOG.warn("J2K can not convert BlockStatement yet")
+        j2kTODO("BlockStatement")
     }
 
     override fun visitBreakStatement(statement: PsiBreakStatement) {
         super.visitBreakStatement(statement)
-        LOG.warn("J2K can not convert BreakStatement yet")
+        j2kTODO("BreakStatement")
     }
 
     override fun visitClass(aClass: PsiClass) {
@@ -87,13 +115,13 @@ class JavaElementConverter(
         val translatedCompanion = if (!staticMembers.isEmpty()) {
             val translatedCompanionBlock = staticMembers
                 .map { "@JvmStatic ${it.translate(indentDelta = 2)}" }
-                .buildCodeBlock()
+                .buildCodeBlock(indentDelta = 2)
                 .spacePrefixed
             "companion object$translatedCompanionBlock"
         } else ""
 
         val translatedBody = (listOf(translatedCompanion) + translatedInstanceMembers)
-            .buildCodeBlock()
+            .buildCodeBlock(indentDelta = 1)
             .spacePrefixed
 
         translatedKotlinCode = "class ${aClass.qualifiedName}$translatedBody"
@@ -105,7 +133,7 @@ class JavaElementConverter(
 
     override fun visitClassObjectAccessExpression(expression: PsiClassObjectAccessExpression) {
         super.visitClassObjectAccessExpression(expression)
-        LOG.warn("J2K can not convert ClassObjectAccessExpression yet")
+        j2kTODO("ClassObjectAccessExpression")
     }
 
     override fun visitCodeBlock(block: PsiCodeBlock) {
@@ -115,7 +143,7 @@ class JavaElementConverter(
 
     override fun visitConditionalExpression(expression: PsiConditionalExpression) {
         super.visitConditionalExpression(expression)
-        LOG.warn("J2K can not convert ConditionalExpression yet")
+        j2kTODO("ConditionalExpression")
     }
 
     override fun visitContinueStatement(statement: PsiContinueStatement) {
@@ -124,27 +152,27 @@ class JavaElementConverter(
 
     override fun visitDeclarationStatement(statement: PsiDeclarationStatement) {
         super.visitDeclarationStatement(statement)
-        LOG.warn("J2K can not convert DeclarationStatement yet")
+        j2kTODO("DeclarationStatement")
     }
 
     override fun visitDocComment(comment: PsiDocComment) {
         super.visitDocComment(comment)
-        LOG.warn("J2K can not convert DocComment yet")
+        j2kTODO("DocComment")
     }
 
     override fun visitDocTag(tag: PsiDocTag) {
         super.visitDocTag(tag)
-        LOG.warn("J2K can not convert DocTag yet")
+        j2kTODO("DocTag")
     }
 
     override fun visitDocTagValue(value: PsiDocTagValue) {
         super.visitDocTagValue(value)
-        LOG.warn("J2K can not convert DocTagValue yet")
+        j2kTODO("DocTagValue")
     }
 
     override fun visitDoWhileStatement(statement: PsiDoWhileStatement) {
         super.visitDoWhileStatement(statement)
-        LOG.warn("J2K can not convert DoWhileStatement yet")
+        j2kTODO("DoWhileStatement")
     }
 
     override fun visitEmptyStatement(statement: PsiEmptyStatement) {
@@ -156,33 +184,29 @@ class JavaElementConverter(
     }
 
     override fun visitExpressionList(list: PsiExpressionList) {
-        super.visitExpressionList(list)
-        LOG.warn("J2K can not convert ExpressionList yet")
+        translatedKotlinCode = list.expressions.asSequence().map { it.translate() }.joinToString(separator = ", ")
     }
 
     override fun visitExpressionListStatement(statement: PsiExpressionListStatement) {
-        super.visitExpressionListStatement(statement)
-        LOG.warn("J2K can not convert ExpressionListStatement yet")
+        visitExpressionList(statement.expressionList)
     }
 
     override fun visitExpressionStatement(statement: PsiExpressionStatement) {
-        super.visitExpressionStatement(statement)
-        LOG.warn("J2K can not convert ExpressionStatement yet")
+        translatedKotlinCode = statement.expression.translate()
     }
 
     override fun visitField(field: PsiField) {
-        super.visitField(field)
-        LOG.warn("J2K can not convert Field yet")
+        visitVariable(field)
     }
 
     override fun visitForStatement(statement: PsiForStatement) {
         super.visitForStatement(statement)
-        LOG.warn("J2K can not convert ForStatement yet")
+        j2kTODO("ForStatement")
     }
 
     override fun visitForeachStatement(statement: PsiForeachStatement) {
         super.visitForeachStatement(statement)
-        LOG.warn("J2K can not convert ForeachStatement yet")
+        j2kTODO("ForeachStatement")
     }
 
     override fun visitIdentifier(identifier: PsiIdentifier) {
@@ -197,52 +221,52 @@ class JavaElementConverter(
 
     override fun visitImportList(list: PsiImportList) {
         super.visitImportList(list)
-        LOG.warn("J2K can not convert ImportList yet")
+        j2kTODO("ImportList")
     }
 
     override fun visitImportStatement(statement: PsiImportStatement) {
         super.visitImportStatement(statement)
-        LOG.warn("J2K can not convert ImportStatement yet")
+        j2kTODO("ImportStatement")
     }
 
     override fun visitImportStaticStatement(statement: PsiImportStaticStatement) {
         super.visitImportStaticStatement(statement)
-        LOG.warn("J2K can not convert ImportStaticStatement yet")
+        j2kTODO("ImportStaticStatement")
     }
 
     override fun visitInlineDocTag(tag: PsiInlineDocTag) {
         super.visitInlineDocTag(tag)
-        LOG.warn("J2K can not convert InlineDocTag yet")
+        j2kTODO("InlineDocTag")
     }
 
     override fun visitInstanceOfExpression(expression: PsiInstanceOfExpression) {
         super.visitInstanceOfExpression(expression)
-        LOG.warn("J2K can not convert InstanceOfExpression yet")
+        j2kTODO("InstanceOfExpression")
     }
 
     override fun visitJavaToken(token: PsiJavaToken) {
         super.visitJavaToken(token)
-        LOG.warn("J2K can not convert JavaToken yet")
+        j2kTODO("JavaToken")
     }
 
     override fun visitKeyword(keyword: PsiKeyword) {
         super.visitKeyword(keyword)
-        LOG.warn("J2K can not convert Keyword yet")
+        j2kTODO("Keyword")
     }
 
     override fun visitLabeledStatement(statement: PsiLabeledStatement) {
         super.visitLabeledStatement(statement)
-        LOG.warn("J2K can not convert LabeledStatement yet")
+        j2kTODO("LabeledStatement")
     }
 
     override fun visitLiteralExpression(expression: PsiLiteralExpression) {
         super.visitLiteralExpression(expression)
-        LOG.warn("J2K can not convert LiteralExpression yet")
+        j2kTODO("LiteralExpression")
     }
 
     override fun visitLocalVariable(variable: PsiLocalVariable) {
         super.visitLocalVariable(variable)
-        LOG.warn("J2K can not convert LocalVariable yet")
+        j2kTODO("LocalVariable")
     }
 
     override fun visitMethod(method: PsiMethod) {
@@ -252,33 +276,32 @@ class JavaElementConverter(
     }
 
     override fun visitMethodCallExpression(expression: PsiMethodCallExpression) {
-        super.visitMethodCallExpression(expression)
-        LOG.warn("J2K can not convert MethodCallExpression yet")
+        translatedKotlinCode = "${expression.methodExpression.translate()}(${expression.argumentList.translate()})"
     }
 
     override fun visitCallExpression(callExpression: PsiCallExpression) {
         super.visitCallExpression(callExpression)
-        LOG.warn("J2K can not convert CallExpression yet")
+        j2kTODO("CallExpression")
     }
 
     override fun visitModifierList(list: PsiModifierList) {
         super.visitModifierList(list)
-        LOG.warn("J2K can not convert ModifierList yet")
+        j2kTODO("ModifierList")
     }
 
     override fun visitNewExpression(expression: PsiNewExpression) {
         super.visitNewExpression(expression)
-        LOG.warn("J2K can not convert NewExpression yet")
+        j2kTODO("NewExpression")
     }
 
     override fun visitPackage(aPackage: PsiPackage) {
         super.visitPackage(aPackage)
-        LOG.warn("J2K can not convert Package yet")
+        j2kTODO("Package")
     }
 
     override fun visitPackageStatement(statement: PsiPackageStatement) {
         super.visitPackageStatement(statement)
-        LOG.warn("J2K can not convert PackageStatement yet")
+        j2kTODO("PackageStatement")
     }
 
     override fun visitParameter(parameter: PsiParameter) {
@@ -288,7 +311,7 @@ class JavaElementConverter(
 
     override fun visitReceiverParameter(parameter: PsiReceiverParameter) {
         super.visitReceiverParameter(parameter)
-        LOG.warn("J2K can not convert ReceiverParameter yet")
+        j2kTODO("ReceiverParameter")
     }
 
     override fun visitParameterList(list: PsiParameterList) {
@@ -299,147 +322,151 @@ class JavaElementConverter(
 
     override fun visitParenthesizedExpression(expression: PsiParenthesizedExpression) {
         super.visitParenthesizedExpression(expression)
-        LOG.warn("J2K can not convert ParenthesizedExpression yet")
+        j2kTODO("ParenthesizedExpression")
     }
 
     override fun visitUnaryExpression(expression: PsiUnaryExpression) {
         super.visitUnaryExpression(expression)
-        LOG.warn("J2K can not convert UnaryExpression yet")
+        j2kTODO("UnaryExpression")
     }
 
     override fun visitPostfixExpression(expression: PsiPostfixExpression) {
         super.visitPostfixExpression(expression)
-        LOG.warn("J2K can not convert PostfixExpression yet")
+        j2kTODO("PostfixExpression")
     }
 
     override fun visitPrefixExpression(expression: PsiPrefixExpression) {
         super.visitPrefixExpression(expression)
-        LOG.warn("J2K can not convert PrefixExpression yet")
+        j2kTODO("PrefixExpression")
     }
 
     override fun visitReferenceElement(reference: PsiJavaCodeReferenceElement) {
         super.visitReferenceElement(reference)
-        LOG.warn("J2K can not convert ReferenceElement yet")
+        j2kTODO("ReferenceElement")
     }
 
     override fun visitImportStaticReferenceElement(reference: PsiImportStaticReferenceElement) {
         super.visitImportStaticReferenceElement(reference)
-        LOG.warn("J2K can not convert ImportStaticReferenceElement yet")
+        j2kTODO("ImportStaticReferenceElement")
     }
 
-    override fun visitReferenceExpression(expression: PsiReferenceExpression) {}
+    override fun visitReferenceExpression(expression: PsiReferenceExpression) {
+        translatedKotlinCode = expression.referenceNameElement.translate()
+    }
 
     override fun visitMethodReferenceExpression(expression: PsiMethodReferenceExpression) {
         super.visitMethodReferenceExpression(expression)
-        LOG.warn("J2K can not convert MethodReferenceExpression yet")
+        j2kTODO("MethodReferenceExpression")
     }
 
     override fun visitReferenceList(list: PsiReferenceList) {
         super.visitReferenceList(list)
-        LOG.warn("J2K can not convert ReferenceList yet")
+        j2kTODO("ReferenceList")
     }
 
     override fun visitReferenceParameterList(list: PsiReferenceParameterList) {
         super.visitReferenceParameterList(list)
-        LOG.warn("J2K can not convert ReferenceParameterList yet")
+        j2kTODO("ReferenceParameterList")
     }
 
     override fun visitTypeParameterList(list: PsiTypeParameterList) {
         super.visitTypeParameterList(list)
-        LOG.warn("J2K can not convert TypeParameterList yet")
+        j2kTODO("TypeParameterList")
     }
 
     override fun visitReturnStatement(statement: PsiReturnStatement) {
         super.visitReturnStatement(statement)
-        LOG.warn("J2K can not convert ReturnStatement yet")
+        j2kTODO("ReturnStatement")
     }
 
     override fun visitStatement(statement: PsiStatement) {
         super.visitStatement(statement)
-        LOG.warn("J2K can not convert Statement yet")
+        j2kTODO("Statement")
     }
 
     override fun visitSuperExpression(expression: PsiSuperExpression) {
         super.visitSuperExpression(expression)
-        LOG.warn("J2K can not convert SuperExpression yet")
+        j2kTODO("SuperExpression")
     }
 
     override fun visitSwitchLabelStatement(statement: PsiSwitchLabelStatement) {
         super.visitSwitchLabelStatement(statement)
-        LOG.warn("J2K can not convert SwitchLabelStatement yet")
+        j2kTODO("SwitchLabelStatement")
     }
 
     override fun visitSwitchLabeledRuleStatement(statement: PsiSwitchLabeledRuleStatement) {
         super.visitSwitchLabeledRuleStatement(statement)
-        LOG.warn("J2K can not convert SwitchLabeledRuleStatement yet")
+        j2kTODO("SwitchLabeledRuleStatement")
     }
 
     override fun visitSwitchStatement(statement: PsiSwitchStatement) {
         super.visitSwitchStatement(statement)
-        LOG.warn("J2K can not convert SwitchStatement yet")
+        j2kTODO("SwitchStatement")
     }
 
     override fun visitSynchronizedStatement(statement: PsiSynchronizedStatement) {
         super.visitSynchronizedStatement(statement)
-        LOG.warn("J2K can not convert SynchronizedStatement yet")
+        j2kTODO("SynchronizedStatement")
     }
 
     override fun visitThisExpression(expression: PsiThisExpression) {
         super.visitThisExpression(expression)
-        LOG.warn("J2K can not convert ThisExpression yet")
+        j2kTODO("ThisExpression")
     }
 
     override fun visitThrowStatement(statement: PsiThrowStatement) {
         super.visitThrowStatement(statement)
-        LOG.warn("J2K can not convert ThrowStatement yet")
+        j2kTODO("ThrowStatement")
     }
 
     override fun visitTryStatement(statement: PsiTryStatement) {
         super.visitTryStatement(statement)
-        LOG.warn("J2K can not convert TryStatement yet")
+        j2kTODO("TryStatement")
     }
 
     override fun visitCatchSection(section: PsiCatchSection) {
         super.visitCatchSection(section)
-        LOG.warn("J2K can not convert CatchSection yet")
+        j2kTODO("CatchSection")
     }
 
     override fun visitResourceList(resourceList: PsiResourceList) {
         super.visitResourceList(resourceList)
-        LOG.warn("J2K can not convert ResourceList yet")
+        j2kTODO("ResourceList")
     }
 
     override fun visitResourceVariable(variable: PsiResourceVariable) {
         super.visitResourceVariable(variable)
-        LOG.warn("J2K can not convert ResourceVariable yet")
+        j2kTODO("ResourceVariable")
     }
 
     override fun visitResourceExpression(expression: PsiResourceExpression) {
         super.visitResourceExpression(expression)
-        LOG.warn("J2K can not convert ResourceExpression yet")
+        j2kTODO("ResourceExpression")
     }
 
     override fun visitTypeElement(type: PsiTypeElement) {
         super.visitTypeElement(type)
-        LOG.warn("J2K can not convert TypeElement yet")
+        j2kTODO("TypeElement")
     }
 
     override fun visitTypeCastExpression(expression: PsiTypeCastExpression) {
-        super.visitTypeCastExpression(expression)
-        LOG.warn("J2K can not convert TypeCastExpression yet")
+        translatedKotlinCode = "() as $"
     }
 
     override fun visitVariable(variable: PsiVariable) {
-        super.visitVariable(variable)
-        LOG.warn("J2K can not convert Variable yet")
+        // TODO: Nullability
+        val keyword = if (variable.hasModifierProperty(PsiModifier.FINAL)) "val" else "var"
+        val translatedInitializer = variable.initializer.translate()?.let { " = $it" } ?: ""
+        translatedKotlinCode = "$keyword ${variable.name}: ${variable.type.translate()}$translatedInitializer"
     }
 
     override fun visitWhileStatement(statement: PsiWhileStatement) {
         super.visitWhileStatement(statement)
-        LOG.warn("J2K can not convert WhileStatement yet")
+        j2kTODO("WhileStatement")
     }
 
     override fun visitJavaFile(file: PsiJavaFile) {
+        // This is the entry point for the J2K converter
         // TODO: Package declarations, imports, ....
         translatedKotlinCode = file.children.asSequence()
             .mapNotNull { it.translate() }
@@ -448,107 +475,107 @@ class JavaElementConverter(
 
     override fun visitImplicitVariable(variable: ImplicitVariable) {
         super.visitImplicitVariable(variable)
-        LOG.warn("J2K can not convert ImplicitVariable yet")
+        j2kTODO("ImplicitVariable")
     }
 
     override fun visitDocToken(token: PsiDocToken) {
         super.visitDocToken(token)
-        LOG.warn("J2K can not convert DocToken yet")
+        j2kTODO("DocToken")
     }
 
     override fun visitTypeParameter(classParameter: PsiTypeParameter) {
         super.visitTypeParameter(classParameter)
-        LOG.warn("J2K can not convert TypeParameter yet")
+        j2kTODO("TypeParameter")
     }
 
     override fun visitAnnotation(annotation: PsiAnnotation) {
         super.visitAnnotation(annotation)
-        LOG.warn("J2K can not convert Annotation yet")
+        j2kTODO("Annotation")
     }
 
     override fun visitAnnotationParameterList(list: PsiAnnotationParameterList) {
         super.visitAnnotationParameterList(list)
-        LOG.warn("J2K can not convert AnnotationParameterList yet")
+        j2kTODO("AnnotationParameterList")
     }
 
     override fun visitAnnotationArrayInitializer(initializer: PsiArrayInitializerMemberValue) {
         super.visitAnnotationArrayInitializer(initializer)
-        LOG.warn("J2K can not convert AnnotationArrayInitializer yet")
+        j2kTODO("AnnotationArrayInitializer")
     }
 
     override fun visitNameValuePair(pair: PsiNameValuePair) {
         super.visitNameValuePair(pair)
-        LOG.warn("J2K can not convert NameValuePair yet")
+        j2kTODO("NameValuePair")
     }
 
     override fun visitAnnotationMethod(method: PsiAnnotationMethod) {
         super.visitAnnotationMethod(method)
-        LOG.warn("J2K can not convert AnnotationMethod yet")
+        j2kTODO("AnnotationMethod")
     }
 
     override fun visitEnumConstant(enumConstant: PsiEnumConstant) {
         super.visitEnumConstant(enumConstant)
-        LOG.warn("J2K can not convert EnumConstant yet")
+        j2kTODO("EnumConstant")
     }
 
     override fun visitEnumConstantInitializer(enumConstantInitializer: PsiEnumConstantInitializer) {
         super.visitEnumConstantInitializer(enumConstantInitializer)
-        LOG.warn("J2K can not convert EnumConstantInitializer yet")
+        j2kTODO("EnumConstantInitializer")
     }
 
     override fun visitCodeFragment(codeFragment: JavaCodeFragment) {
         super.visitCodeFragment(codeFragment)
-        LOG.warn("J2K can not convert CodeFragment yet")
+        j2kTODO("CodeFragment")
     }
 
     override fun visitPolyadicExpression(expression: PsiPolyadicExpression) {
         super.visitPolyadicExpression(expression)
-        LOG.warn("J2K can not convert PolyadicExpression yet")
+        j2kTODO("PolyadicExpression")
     }
 
     override fun visitLambdaExpression(expression: PsiLambdaExpression) {
         super.visitLambdaExpression(expression)
-        LOG.warn("J2K can not convert LambdaExpression yet")
+        j2kTODO("LambdaExpression")
     }
 
     override fun visitSwitchExpression(expression: PsiSwitchExpression) {
         super.visitSwitchExpression(expression)
-        LOG.warn("J2K can not convert SwitchExpression yet")
+        j2kTODO("SwitchExpression")
     }
 
     override fun visitModule(module: PsiJavaModule) {
         super.visitModule(module)
-        LOG.warn("J2K can not convert Module yet")
+        j2kTODO("Module")
     }
 
     override fun visitModuleReferenceElement(refElement: PsiJavaModuleReferenceElement) {
         super.visitModuleReferenceElement(refElement)
-        LOG.warn("J2K can not convert ModuleReferenceElement yet")
+        j2kTODO("ModuleReferenceElement")
     }
 
     override fun visitModuleStatement(statement: PsiStatement) {
         super.visitModuleStatement(statement)
-        LOG.warn("J2K can not convert ModuleStatement yet")
+        j2kTODO("ModuleStatement")
     }
 
     override fun visitRequiresStatement(statement: PsiRequiresStatement) {
         super.visitRequiresStatement(statement)
-        LOG.warn("J2K can not convert RequiresStatement yet")
+        j2kTODO("RequiresStatement")
     }
 
     override fun visitPackageAccessibilityStatement(statement: PsiPackageAccessibilityStatement) {
         super.visitPackageAccessibilityStatement(statement)
-        LOG.warn("J2K can not convert PackageAccessibilityStatement yet")
+        j2kTODO("PackageAccessibilityStatement")
     }
 
     override fun visitUsesStatement(statement: PsiUsesStatement) {
         super.visitUsesStatement(statement)
-        LOG.warn("J2K can not convert UsesStatement yet")
+        j2kTODO("UsesStatement")
     }
 
     override fun visitProvidesStatement(statement: PsiProvidesStatement) {
         super.visitProvidesStatement(statement)
-        LOG.warn("J2K can not convert ProvidesStatement yet")
+        j2kTODO("ProvidesStatement")
     }
 }
 

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt
@@ -89,18 +89,17 @@ class JavaElementConverter(
     }
 
     override fun visitAssertStatement(statement: PsiAssertStatement) {
-        super.visitAssertStatement(statement)
-        j2kTODO("AssertStatement")
+        val translatedCondition = statement.assertCondition.translate()
+        val translatedDescription = statement.assertDescription.translate()?.let { " { $it }" } ?: ""
+        translatedKotlinCode = "assert($translatedCondition)$translatedDescription"
     }
 
     override fun visitAssignmentExpression(expression: PsiAssignmentExpression) {
-        super.visitAssignmentExpression(expression)
-        j2kTODO("AssignmentExpression")
+        translatedKotlinCode = "${expression.lExpression.translate()} ${expression.operationSign.text} ${expression.rExpression.translate()}"
     }
 
     override fun visitBinaryExpression(expression: PsiBinaryExpression) {
-        super.visitBinaryExpression(expression)
-        j2kTODO("BinaryExpression")
+        translatedKotlinCode = "${expression.lOperand.translate()} ${expression.operationSign.text} ${expression.rOperand.translate()}"
     }
 
     override fun visitBlockStatement(statement: PsiBlockStatement) {
@@ -254,8 +253,7 @@ class JavaElementConverter(
     }
 
     override fun visitJavaToken(token: PsiJavaToken) {
-        super.visitJavaToken(token)
-        j2kTODO("JavaToken")
+        translatedKotlinCode = token.text
     }
 
     override fun visitKeyword(keyword: PsiKeyword) {
@@ -305,18 +303,25 @@ class JavaElementConverter(
     }
 
     override fun visitNewExpression(expression: PsiNewExpression) {
-        super.visitNewExpression(expression)
-        j2kTODO("NewExpression")
+        val qualifier = expression.qualifier?.translate()?.let { "$it." } ?: ""
+        val name = expression.type?.translate()
+
+        val arrayDimensions = expression.arrayDimensions
+        val translatedArgs = if (arrayDimensions.isEmpty()) {
+            "(${expression.argumentList.translate()})"
+        } else {
+            arrayDimensions.map { "[$it]" }.joinToString()
+        }
+
+        translatedKotlinCode = "$qualifier$name$translatedArgs"
     }
 
     override fun visitPackage(aPackage: PsiPackage) {
-        super.visitPackage(aPackage)
-        j2kTODO("Package")
+        translatedKotlinCode = aPackage.qualifiedName
     }
 
     override fun visitPackageStatement(statement: PsiPackageStatement) {
-        super.visitPackageStatement(statement)
-        j2kTODO("PackageStatement")
+        translatedKotlinCode = "package ${statement.packageName}"
     }
 
     override fun visitParameter(parameter: PsiParameter) {
@@ -336,23 +341,21 @@ class JavaElementConverter(
     }
 
     override fun visitParenthesizedExpression(expression: PsiParenthesizedExpression) {
-        super.visitParenthesizedExpression(expression)
-        j2kTODO("ParenthesizedExpression")
+        translatedKotlinCode = "(${expression.expression.translate()})"
     }
 
     override fun visitUnaryExpression(expression: PsiUnaryExpression) {
+        // Implemented by prefix/postfix expression
         super.visitUnaryExpression(expression)
         j2kTODO("UnaryExpression")
     }
 
     override fun visitPostfixExpression(expression: PsiPostfixExpression) {
-        super.visitPostfixExpression(expression)
-        j2kTODO("PostfixExpression")
+        translatedKotlinCode = "${expression.operand.translate()}${expression.operationSign.text}"
     }
 
     override fun visitPrefixExpression(expression: PsiPrefixExpression) {
-        super.visitPrefixExpression(expression)
-        j2kTODO("PrefixExpression")
+        translatedKotlinCode = "${expression.operationSign.text}${expression.operand.translate()}"
     }
 
     override fun visitReferenceElement(reference: PsiJavaCodeReferenceElement) {

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt
@@ -1,0 +1,416 @@
+package org.javacs.kt.j2k
+
+import org.jetbrains.kotlin.com.intellij.psi.*
+import org.jetbrains.kotlin.com.intellij.psi.javadoc.*
+
+/**
+ * A Psi visitor that converts Java elements into
+ * Kotlin code.
+ */
+class JavaElementConverter(
+    private val indentLevel: Int = 0,
+    private val indentSize: Int = 4 // spaces
+) : JavaElementVisitor() {
+    var translatedKotlinCode: String? = null
+        private set
+    private val indent: String = "".padStart(indentLevel * indentSize, ' ')
+
+    override fun visitAnonymousClass(aClass: PsiAnonymousClass) {
+        super.visitAnonymousClass(aClass)
+    }
+
+    override fun visitArrayAccessExpression(expression: PsiArrayAccessExpression) {
+        super.visitArrayAccessExpression(expression)
+    }
+
+    override fun visitArrayInitializerExpression(expression: PsiArrayInitializerExpression) {
+        super.visitArrayInitializerExpression(expression)
+    }
+
+    override fun visitAssertStatement(statement: PsiAssertStatement) {
+        super.visitAssertStatement(statement)
+    }
+
+    override fun visitAssignmentExpression(expression: PsiAssignmentExpression) {
+        super.visitAssignmentExpression(expression)
+    }
+
+    override fun visitBinaryExpression(expression: PsiBinaryExpression) {
+        super.visitBinaryExpression(expression)
+    }
+
+    override fun visitBlockStatement(statement: PsiBlockStatement) {
+        super.visitBlockStatement(statement)
+    }
+
+    override fun visitBreakStatement(statement: PsiBreakStatement) {
+        super.visitBreakStatement(statement)
+    }
+
+    override fun visitClass(aClass: PsiClass) {
+        super.visitClass(aClass)
+    }
+
+    override fun visitClassInitializer(initializer: PsiClassInitializer) {
+        super.visitClassInitializer(initializer)
+    }
+
+    override fun visitClassObjectAccessExpression(expression: PsiClassObjectAccessExpression) {
+        super.visitClassObjectAccessExpression(expression)
+    }
+
+    override fun visitCodeBlock(block: PsiCodeBlock) {
+        super.visitCodeBlock(block)
+    }
+
+    override fun visitConditionalExpression(expression: PsiConditionalExpression) {
+        super.visitConditionalExpression(expression)
+    }
+
+    override fun visitContinueStatement(statement: PsiContinueStatement) {
+        super.visitContinueStatement(statement)
+    }
+
+    override fun visitDeclarationStatement(statement: PsiDeclarationStatement) {
+        super.visitDeclarationStatement(statement)
+    }
+
+    override fun visitDocComment(comment: PsiDocComment) {
+        super.visitDocComment(comment)
+    }
+
+    override fun visitDocTag(tag: PsiDocTag) {
+        super.visitDocTag(tag)
+    }
+
+    override fun visitDocTagValue(value: PsiDocTagValue) {
+        super.visitDocTagValue(value)
+    }
+
+    override fun visitDoWhileStatement(statement: PsiDoWhileStatement) {
+        super.visitDoWhileStatement(statement)
+    }
+
+    override fun visitEmptyStatement(statement: PsiEmptyStatement) {
+        super.visitEmptyStatement(statement)
+    }
+
+    override fun visitExpression(expression: PsiExpression) {
+        super.visitExpression(expression)
+    }
+
+    override fun visitExpressionList(list: PsiExpressionList) {
+        super.visitExpressionList(list)
+    }
+
+    override fun visitExpressionListStatement(statement: PsiExpressionListStatement) {
+        super.visitExpressionListStatement(statement)
+    }
+
+    override fun visitExpressionStatement(statement: PsiExpressionStatement) {
+        super.visitExpressionStatement(statement)
+    }
+
+    override fun visitField(field: PsiField) {
+        super.visitField(field)
+    }
+
+    override fun visitForStatement(statement: PsiForStatement) {
+        super.visitForStatement(statement)
+    }
+
+    override fun visitForeachStatement(statement: PsiForeachStatement) {
+        super.visitForeachStatement(statement)
+    }
+
+    override fun visitIdentifier(identifier: PsiIdentifier) {
+        super.visitIdentifier(identifier)
+    }
+
+    override fun visitIfStatement(statement: PsiIfStatement) {
+        super.visitIfStatement(statement)
+    }
+
+    override fun visitImportList(list: PsiImportList) {
+        super.visitImportList(list)
+    }
+
+    override fun visitImportStatement(statement: PsiImportStatement) {
+        super.visitImportStatement(statement)
+    }
+
+    override fun visitImportStaticStatement(statement: PsiImportStaticStatement) {
+        super.visitImportStaticStatement(statement)
+    }
+
+    override fun visitInlineDocTag(tag: PsiInlineDocTag) {
+        super.visitInlineDocTag(tag)
+    }
+
+    override fun visitInstanceOfExpression(expression: PsiInstanceOfExpression) {
+        super.visitInstanceOfExpression(expression)
+    }
+
+    override fun visitJavaToken(token: PsiJavaToken) {
+        super.visitJavaToken(token)
+    }
+
+    override fun visitKeyword(keyword: PsiKeyword) {
+        super.visitKeyword(keyword)
+    }
+
+    override fun visitLabeledStatement(statement: PsiLabeledStatement) {
+        super.visitLabeledStatement(statement)
+    }
+
+    override fun visitLiteralExpression(expression: PsiLiteralExpression) {
+        super.visitLiteralExpression(expression)
+    }
+
+    override fun visitLocalVariable(variable: PsiLocalVariable) {
+        super.visitLocalVariable(variable)
+    }
+
+    override fun visitMethod(method: PsiMethod) {
+        super.visitMethod(method)
+    }
+
+    override fun visitMethodCallExpression(expression: PsiMethodCallExpression) {
+        super.visitMethodCallExpression(expression)
+    }
+
+    override fun visitCallExpression(callExpression: PsiCallExpression) {
+        super.visitCallExpression(callExpression)
+    }
+
+    override fun visitModifierList(list: PsiModifierList) {
+        super.visitModifierList(list)
+    }
+
+    override fun visitNewExpression(expression: PsiNewExpression) {
+        super.visitNewExpression(expression)
+    }
+
+    override fun visitPackage(aPackage: PsiPackage) {
+        super.visitPackage(aPackage)
+    }
+
+    override fun visitPackageStatement(statement: PsiPackageStatement) {
+        super.visitPackageStatement(statement)
+    }
+
+    override fun visitParameter(parameter: PsiParameter) {
+        super.visitParameter(parameter)
+    }
+
+    override fun visitReceiverParameter(parameter: PsiReceiverParameter) {
+        super.visitReceiverParameter(parameter)
+    }
+
+    override fun visitParameterList(list: PsiParameterList) {
+        super.visitParameterList(list)
+    }
+
+    override fun visitParenthesizedExpression(expression: PsiParenthesizedExpression) {
+        super.visitParenthesizedExpression(expression)
+    }
+
+    override fun visitUnaryExpression(expression: PsiUnaryExpression) {
+        super.visitUnaryExpression(expression)
+    }
+
+    override fun visitPostfixExpression(expression: PsiPostfixExpression) {
+        super.visitPostfixExpression(expression)
+    }
+
+    override fun visitPrefixExpression(expression: PsiPrefixExpression) {
+        super.visitPrefixExpression(expression)
+    }
+
+    override fun visitReferenceElement(reference: PsiJavaCodeReferenceElement) {
+        super.visitReferenceElement(reference)
+    }
+
+    override fun visitImportStaticReferenceElement(reference: PsiImportStaticReferenceElement) {
+        super.visitImportStaticReferenceElement(reference)
+    }
+
+    override fun visitReferenceExpression(expression: PsiReferenceExpression) {}
+
+    override fun visitMethodReferenceExpression(expression: PsiMethodReferenceExpression) {
+        super.visitMethodReferenceExpression(expression)
+    }
+
+    override fun visitReferenceList(list: PsiReferenceList) {
+        super.visitReferenceList(list)
+    }
+
+    override fun visitReferenceParameterList(list: PsiReferenceParameterList) {
+        super.visitReferenceParameterList(list)
+    }
+
+    override fun visitTypeParameterList(list: PsiTypeParameterList) {
+        super.visitTypeParameterList(list)
+    }
+
+    override fun visitReturnStatement(statement: PsiReturnStatement) {
+        super.visitReturnStatement(statement)
+    }
+
+    override fun visitStatement(statement: PsiStatement) {
+        super.visitStatement(statement)
+    }
+
+    override fun visitSuperExpression(expression: PsiSuperExpression) {
+        super.visitSuperExpression(expression)
+    }
+
+    override fun visitSwitchLabelStatement(statement: PsiSwitchLabelStatement) {
+        super.visitSwitchLabelStatement(statement)
+    }
+
+    override fun visitSwitchLabeledRuleStatement(statement: PsiSwitchLabeledRuleStatement) {
+        super.visitSwitchLabeledRuleStatement(statement)
+    }
+
+    override fun visitSwitchStatement(statement: PsiSwitchStatement) {
+        super.visitSwitchStatement(statement)
+    }
+
+    override fun visitSynchronizedStatement(statement: PsiSynchronizedStatement) {
+        super.visitSynchronizedStatement(statement)
+    }
+
+    override fun visitThisExpression(expression: PsiThisExpression) {
+        super.visitThisExpression(expression)
+    }
+
+    override fun visitThrowStatement(statement: PsiThrowStatement) {
+        super.visitThrowStatement(statement)
+    }
+
+    override fun visitTryStatement(statement: PsiTryStatement) {
+        super.visitTryStatement(statement)
+    }
+
+    override fun visitCatchSection(section: PsiCatchSection) {
+        super.visitCatchSection(section)
+    }
+
+    override fun visitResourceList(resourceList: PsiResourceList) {
+        super.visitResourceList(resourceList)
+    }
+
+    override fun visitResourceVariable(variable: PsiResourceVariable) {
+        super.visitResourceVariable(variable)
+    }
+
+    override fun visitResourceExpression(expression: PsiResourceExpression) {
+        super.visitResourceExpression(expression)
+    }
+
+    override fun visitTypeElement(type: PsiTypeElement) {
+        super.visitTypeElement(type)
+    }
+
+    override fun visitTypeCastExpression(expression: PsiTypeCastExpression) {
+        super.visitTypeCastExpression(expression)
+    }
+
+    override fun visitVariable(variable: PsiVariable) {
+        super.visitVariable(variable)
+    }
+
+    override fun visitWhileStatement(statement: PsiWhileStatement) {
+        super.visitWhileStatement(statement)
+    }
+
+    override fun visitJavaFile(file: PsiJavaFile) {
+        super.visitJavaFile(file)
+    }
+
+    override fun visitImplicitVariable(variable: ImplicitVariable) {
+        super.visitImplicitVariable(variable)
+    }
+
+    override fun visitDocToken(token: PsiDocToken) {
+        super.visitDocToken(token)
+    }
+
+    override fun visitTypeParameter(classParameter: PsiTypeParameter) {
+        super.visitTypeParameter(classParameter)
+    }
+
+    override fun visitAnnotation(annotation: PsiAnnotation) {
+        super.visitAnnotation(annotation)
+    }
+
+    override fun visitAnnotationParameterList(list: PsiAnnotationParameterList) {
+        super.visitAnnotationParameterList(list)
+    }
+
+    override fun visitAnnotationArrayInitializer(initializer: PsiArrayInitializerMemberValue) {
+        super.visitAnnotationArrayInitializer(initializer)
+    }
+
+    override fun visitNameValuePair(pair: PsiNameValuePair) {
+        super.visitNameValuePair(pair)
+    }
+
+    override fun visitAnnotationMethod(method: PsiAnnotationMethod) {
+        super.visitAnnotationMethod(method)
+    }
+
+    override fun visitEnumConstant(enumConstant: PsiEnumConstant) {
+        super.visitEnumConstant(enumConstant)
+    }
+
+    override fun visitEnumConstantInitializer(enumConstantInitializer: PsiEnumConstantInitializer) {
+        super.visitEnumConstantInitializer(enumConstantInitializer)
+    }
+
+    override fun visitCodeFragment(codeFragment: JavaCodeFragment) {
+        super.visitCodeFragment(codeFragment)
+    }
+
+    override fun visitPolyadicExpression(expression: PsiPolyadicExpression) {
+        super.visitPolyadicExpression(expression)
+    }
+
+    override fun visitLambdaExpression(expression: PsiLambdaExpression) {
+        super.visitLambdaExpression(expression)
+    }
+
+    override fun visitSwitchExpression(expression: PsiSwitchExpression) {
+        super.visitSwitchExpression(expression)
+    }
+
+    override fun visitModule(module: PsiJavaModule) {
+        super.visitModule(module)
+    }
+
+    override fun visitModuleReferenceElement(refElement: PsiJavaModuleReferenceElement) {
+        super.visitModuleReferenceElement(refElement)
+    }
+
+    override fun visitModuleStatement(statement: PsiStatement) {
+        super.visitModuleStatement(statement)
+    }
+
+    override fun visitRequiresStatement(statement: PsiRequiresStatement) {
+        super.visitRequiresStatement(statement)
+    }
+
+    override fun visitPackageAccessibilityStatement(statement: PsiPackageAccessibilityStatement) {
+        super.visitPackageAccessibilityStatement(statement)
+    }
+
+    override fun visitUsesStatement(statement: PsiUsesStatement) {
+        super.visitUsesStatement(statement)
+    }
+
+    override fun visitProvidesStatement(statement: PsiProvidesStatement) {
+        super.visitProvidesStatement(statement)
+    }
+}
+

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt
@@ -13,9 +13,8 @@ fun convertJavaToKotlin(javaCode: String, compiler: Compiler): String {
     val javaAST = psiFactory.createFileFromText("snippet.java", JavaLanguage.INSTANCE, javaCode)
     LOG.info("Parsed {} to {}", javaCode, javaAST)
 
-	// return JavaToKotlinTranslator.generateKotlinCode(
-	// 	nonNull(javaCode, "No Java code has been provided to the J2K-converter"),
-	// 	nonNull(project, "No project is present in the KotlinCoreEnvironment")
-	// )
-	TODO()
+	return JavaElementConverter().also(javaAST::accept).translatedKotlinCode ?: run {
+        LOG.warn("Could not translate code")
+        ""
+    }
 }

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt
@@ -1,5 +1,7 @@
 package org.javacs.kt.j2k
 
+import org.jetbrains.kotlin.com.intellij.lang.java.JavaLanguage
+import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 // import org.jetbrains.kotlin.j2k.JavaToKotlinTranslator
 import org.javacs.kt.LOG
@@ -7,8 +9,9 @@ import org.javacs.kt.Compiler
 import org.javacs.kt.util.nonNull
 
 fun convertJavaToKotlin(javaCode: String, compiler: Compiler): String {
-	val project = compiler.environment.project
-	LOG.info("Converting to Kotlin: {} with project {}", javaCode, project)
+    val psiFactory = PsiFileFactory.getInstance(compiler.environment.project)
+    val javaAST = psiFactory.createFileFromText("snippet.java", JavaLanguage.INSTANCE, javaCode)
+    LOG.info("Parsed {} to {}", javaCode, javaAST)
 
 	// return JavaToKotlinTranslator.generateKotlinCode(
 	// 	nonNull(javaCode, "No Java code has been provided to the J2K-converter"),

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaTypeConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaTypeConverter.kt
@@ -12,23 +12,29 @@ object JavaTypeConverter : PsiTypeVisitor<String>() {
         else -> primitiveType.canonicalText.capitalize()
     }
 
-    override fun visitArrayType(arrayType: PsiArrayType): String {
-        return "Array<${arrayType.componentType.accept(this)}>"
-    }
+    override fun visitArrayType(arrayType: PsiArrayType): String =
+        "Array<${arrayType.componentType.accept(this)}>"
 
-    override fun visitClassType(classType: PsiClassType): String = when (classType.className) {
-        "Integer" -> "Int"
-        "Character" -> "Char"
-        else -> super.visitClassType(classType) ?: classType.className
+    override fun visitClassType(classType: PsiClassType): String {
+        val translatedTypeArgs = classType.parameters.asSequence()
+            .map { it.accept(this) }
+            .joinToString(separator = ", ")
+            .let { if (it.isNotEmpty()) "<$it>" else "" }
+        return "${platformType(classType.className)}$translatedTypeArgs"
     }
 
     override fun visitCapturedWildcardType(capturedWildcardType: PsiCapturedWildcardType): String {
         return super.visitCapturedWildcardType(capturedWildcardType) ?: "?"
     }
 
-    override fun visitWildcardType(wildcardType: PsiWildcardType): String {
-        return super.visitWildcardType(wildcardType) ?: "?"
-    }
+    override fun visitWildcardType(wildcardType: PsiWildcardType): String =
+        if (wildcardType.isSuper()) {
+            "in ${wildcardType.bound?.accept(this)}"
+        } else if (wildcardType.isExtends()) {
+            "out ${wildcardType.bound?.accept(this)}"
+        } else {
+            super.visitWildcardType(wildcardType) ?: "?"
+        }
 
     override fun visitEllipsisType(ellipsisType: PsiEllipsisType): String {
         return super.visitEllipsisType(ellipsisType) ?: "?"

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaTypeConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaTypeConverter.kt
@@ -1,0 +1,56 @@
+package org.javacs.kt.j2k
+
+import org.jetbrains.kotlin.com.intellij.psi.*
+
+object JavaTypeConverter : PsiTypeVisitor<String>() {
+    override fun visitType(type: PsiType): String {
+        return type.presentableText
+    }
+
+    override fun visitPrimitiveType(primitiveType: PsiPrimitiveType): String = when (primitiveType.canonicalText) {
+        "void" -> "Unit"
+        else -> primitiveType.canonicalText.capitalize()
+    }
+
+    override fun visitArrayType(arrayType: PsiArrayType): String {
+        return "Array<${arrayType.componentType.accept(this)}>"
+    }
+
+    override fun visitClassType(classType: PsiClassType): String = when (classType.className) {
+        "Integer" -> "Int"
+        "Character" -> "Char"
+        else -> super.visitClassType(classType)
+    }
+
+    override fun visitCapturedWildcardType(capturedWildcardType: PsiCapturedWildcardType): String {
+        return super.visitCapturedWildcardType(capturedWildcardType) ?: "?"
+    }
+
+    override fun visitWildcardType(wildcardType: PsiWildcardType): String {
+        return super.visitWildcardType(wildcardType) ?: "?"
+    }
+
+    override fun visitEllipsisType(ellipsisType: PsiEllipsisType): String {
+        return super.visitEllipsisType(ellipsisType) ?: "?"
+    }
+
+    override fun visitDisjunctionType(disjunctionType: PsiDisjunctionType): String {
+        return super.visitDisjunctionType(disjunctionType) ?: "?"
+    }
+
+    override fun visitIntersectionType(intersectionType: PsiIntersectionType): String {
+        return super.visitIntersectionType(intersectionType) ?: "?"
+    }
+
+    override fun visitDiamondType(diamondType: PsiDiamondType): String {
+        return super.visitDiamondType(diamondType) ?: "?"
+    }
+
+    override fun visitLambdaExpressionType(lambdaExpressionType: PsiLambdaExpressionType): String {
+        return super.visitLambdaExpressionType(lambdaExpressionType) ?: "?"
+    }
+
+    override fun visitMethodReferenceType(methodReferenceType: PsiMethodReferenceType): String {
+        return super.visitMethodReferenceType(methodReferenceType)
+    }
+}

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaTypeConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaTypeConverter.kt
@@ -19,7 +19,7 @@ object JavaTypeConverter : PsiTypeVisitor<String>() {
     override fun visitClassType(classType: PsiClassType): String = when (classType.className) {
         "Integer" -> "Int"
         "Character" -> "Char"
-        else -> super.visitClassType(classType)
+        else -> super.visitClassType(classType) ?: classType.className
     }
 
     override fun visitCapturedWildcardType(capturedWildcardType: PsiCapturedWildcardType): String {

--- a/server/src/main/kotlin/org/javacs/kt/j2k/PlatformTypeConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/PlatformTypeConverter.kt
@@ -1,0 +1,18 @@
+package org.javacs.kt.j2k
+
+private val platformImports = setOf(
+    "java.util.List",
+    "java.util.Set"
+)
+
+fun isPlatformImport(fqJavaType: String) =
+    platformImports.contains(fqJavaType)
+
+fun platformType(javaType: String): String = when (javaType) {
+    "List" -> "MutableList"
+    "Set" -> "MutableSet"
+    "Collection" -> "MutableCollection"
+    "Integer" -> "Int"
+    "Character" -> "Char"
+    else -> javaType
+}

--- a/server/src/test/kotlin/org/javacs/kt/JavaToKotlinTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/JavaToKotlinTest.kt
@@ -1,0 +1,25 @@
+package org.javacs.kt
+
+import org.javacs.kt.j2k.convertJavaToKotlin
+import org.junit.Test
+import org.junit.Assert.assertThat
+import org.hamcrest.Matchers.equalTo
+import java.nio.file.Paths
+
+class JavaToKotlinTest : LanguageServerTestFixture("j2k") {
+    @Test fun `test j2k conversion`() {
+        val javaCode = workspaceRoot
+            .resolve("JavaJSONConverter.java")
+            .toFile()
+            .readText()
+            .trim()
+        val expectedKotlinCode = workspaceRoot
+            .resolve("JavaJSONConverter.kt")
+            .toFile()
+            .readText()
+            .trim()
+        val compiler = languageServer.classPath.compiler
+        val convertedKotlinCode = convertJavaToKotlin(javaCode, compiler)
+        assertThat(convertedKotlinCode, equalTo(expectedKotlinCode))
+    }
+}

--- a/server/src/test/resources/j2k/JavaJSONConverter.java
+++ b/server/src/test/resources/j2k/JavaJSONConverter.java
@@ -1,0 +1,22 @@
+package j2k;
+
+import java.util.List;
+import java.util.Arrays;
+
+public class JavaJSONConverter<T> {
+    public static void main(String[] args) {
+        System.out.println("JSON: " + new JavaJSONConverter<Integer>().toJSONArray(Arrays.asList(98, 23, 34)));
+    }
+
+    public String toJSONArray(List<? extends T> list) {
+        StringBuilder str = new StringBuilder("[");
+        int size = list.size();
+        for (int i = 0; i < size; i++) {
+            str.append(list.get(i));
+            if (i != (size - 1)) {
+                str.append(", ");
+            }
+        }
+        return str.append("]").toString();
+    }
+}

--- a/server/src/test/resources/j2k/JavaJSONConverter.kt
+++ b/server/src/test/resources/j2k/JavaJSONConverter.kt
@@ -1,0 +1,25 @@
+package j2k
+
+import java.util.Arrays
+
+class JavaJSONConverter<T> {
+    companion object {
+        @JvmStatic fun main(args: Array<String>) {
+            System.out.println("JSON: " + JavaJSONConverter<Int>().toJSONArray(Arrays.asList(98, 23, 34)))
+        }
+    }
+
+    fun toJSONArray(list: MutableList<out T>): String {
+        var str: StringBuilder = StringBuilder("[")
+        var size: Int = list.size()
+        var i: Int = 0
+        while (i < size) {
+            str.append(list.get(i))
+            if (i != (size - 1)) {
+                str.append(", ")
+            }
+            i++
+        }
+        return str.append("]").toString()
+    }
+}


### PR DESCRIPTION
Since the old J2K was disabled as of #136, this branch contains a new converter that is written from scratch and based on a [PSI](https://www.jetbrains.org/intellij/sdk/docs/basics/architectural_overview/psi_elements.html) visitor.